### PR TITLE
Broaden notification support detection

### DIFF
--- a/src/stores/notifications.js
+++ b/src/stores/notifications.js
@@ -13,7 +13,13 @@ export const useNotificationStore = defineStore('notifications', () => {
   const eveningTime = useLocalStorage('notifications.evening.time', '18:00')
 
   // Computed properties
-  const isSupported = computed(() => 'Notification' in window)
+  const isSupported = computed(
+    () =>
+      'Notification' in window ||
+      ('serviceWorker' in navigator &&
+        typeof ServiceWorkerRegistration !== 'undefined' &&
+        'showNotification' in ServiceWorkerRegistration.prototype),
+  )
   const isGranted = computed(() => permission.value === 'granted')
   const isDenied = computed(() => permission.value === 'denied')
   const canRequest = computed(() => permission.value === 'default')


### PR DESCRIPTION
## Summary
- remove service worker registration introduced earlier
- detect notification support via `ServiceWorkerRegistration.showNotification` or window `Notification`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a25b0fce80832b9244a79d09aa5007