### PR TITLE
Refactor settings page structure for cleaner responsive UX

### DIFF
--- a/src/views/settings/SettingsView.vue
+++ b/src/views/settings/SettingsView.vue
@@ -1,9 +1,16 @@
 <script setup>
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import Page from '@/components/Layout/Page.vue'
 import Heading from '@/components/Heading.vue'
-
-import { IconBell, IconCloudDownload, IconSettings } from '@tabler/icons-vue'
+import {
+  IconBell,
+  IconBook,
+  IconChevronLeft,
+  IconCloudDownload,
+  IconMoonStars,
+  IconRefreshDot,
+  IconSunFilled,
+} from '@tabler/icons-vue'
 
 import SettingsReciter from './partials/SettingsReciter.vue'
 import SettingsPrayerTimes from './partials/SettingsPrayerTimes.vue'
@@ -12,102 +19,127 @@ import SettingsNotifications from './partials/SettingsNotifications.vue'
 import SettingsDownloadAssets from './partials/SettingsDownloadAssets.vue'
 import SettingsAppUpdates from './partials/SettingsAppUpdates.vue'
 
-const tabs = [
-  { id: 'general', label: 'عام', icon: IconSettings },
-  { id: 'notifications', label: 'الإشعارات', icon: IconBell },
-  { id: 'downloads', label: 'التحميلات', icon: IconCloudDownload },
+const groups = [
+  {
+    title: 'الإعدادات الأساسية',
+    items: [
+      { id: 'prayer-times', label: 'مواقيت الصلاة', icon: IconRefreshDot, component: SettingsPrayerTimes },
+      { id: 'quran', label: 'القرآن الكريم', icon: IconBook, component: SettingsReciter },
+      { id: 'theme', label: 'المظهر', icon: IconSunFilled, component: SettingsTheme },
+      { id: 'updates', label: 'تحديثات التطبيق', icon: IconMoonStars, component: SettingsAppUpdates },
+    ],
+  },
+  {
+    title: 'إعدادات متقدمة',
+    items: [
+      { id: 'notifications', label: 'الإشعارات', icon: IconBell, component: SettingsNotifications },
+      { id: 'downloads', label: 'التحميلات', icon: IconCloudDownload, component: SettingsDownloadAssets },
+    ],
+  },
 ]
 
-const activeTab = ref('general')
+const flatItems = groups.flatMap((group) => group.items)
+const activeItemId = ref('prayer-times')
+
+const activeItem = computed(() => flatItems.find((item) => item.id === activeItemId.value) || flatItems[0])
 </script>
 
 <template>
   <Page>
-    <Heading class="mb-4" title="الإعدادات" subtitle="واجهة إعدادات مبسطة وسهلة الاستخدام" />
+    <Heading class="mb-4" title="الإعدادات" subtitle="اختر قسمًا من القائمة ثم عدّل إعداداته بسهولة" />
 
-    <div class="settings-shell card border-0 shadow-sm">
-      <div class="card-body p-2 p-md-3">
-        <div class="settings-tabs nav nav-pills mb-3" role="tablist" aria-label="أقسام الإعدادات">
-          <button
-            v-for="tab in tabs"
-            :key="tab.id"
-            class="nav-link settings-tab"
-            :class="{ active: activeTab === tab.id }"
-            type="button"
-            role="tab"
-            :aria-selected="activeTab === tab.id"
-            @click="activeTab = tab.id"
-          >
-            <component :is="tab.icon" :size="16" />
-            <span>{{ tab.label }}</span>
-          </button>
-        </div>
+    <div class="settings-shell row g-3 g-lg-4">
+      <div class="col-12 col-lg-4">
+        <aside class="settings-menu card h-100">
+          <div class="card-body p-3">
+            <div v-for="group in groups" :key="group.title" class="settings-group">
+              <h6 class="settings-group-title">{{ group.title }}</h6>
 
-        <div v-show="activeTab === 'general'" class="settings-pane" role="tabpanel">
-          <div class="row g-3">
-            <div class="col-12 col-xl-6">
-              <SettingsPrayerTimes />
-            </div>
-            <div class="col-12 col-xl-6">
-              <SettingsReciter />
-            </div>
-            <div class="col-12 col-xl-6">
-              <SettingsTheme />
-            </div>
-            <div class="col-12 col-xl-6">
-              <SettingsAppUpdates />
+              <button
+                v-for="item in group.items"
+                :key="item.id"
+                type="button"
+                class="settings-item"
+                :class="{ active: activeItemId === item.id }"
+                @click="activeItemId = item.id"
+              >
+                <span class="settings-item-start">
+                  <component :is="item.icon" :size="17" />
+                  <span>{{ item.label }}</span>
+                </span>
+                <IconChevronLeft :size="16" class="settings-item-arrow" />
+              </button>
             </div>
           </div>
-        </div>
+        </aside>
+      </div>
 
-        <div v-show="activeTab === 'notifications'" class="settings-pane" role="tabpanel">
-          <SettingsNotifications />
-        </div>
+      <div class="col-12 col-lg-8">
+        <section class="settings-detail card border-0 bg-transparent">
+          <div class="card-body p-0">
+            <div class="settings-detail-header mb-3">
+              <component :is="activeItem.icon" :size="18" />
+              <h5 class="m-0">{{ activeItem.label }}</h5>
+            </div>
 
-        <div v-show="activeTab === 'downloads'" class="settings-pane" role="tabpanel">
-          <SettingsDownloadAssets />
-        </div>
+            <component :is="activeItem.component" />
+          </div>
+        </section>
       </div>
     </div>
   </Page>
 </template>
 
 <style lang="scss" scoped>
-.settings-shell {
+.settings-group + .settings-group {
+  margin-top: 1rem;
+}
+
+.settings-group-title {
+  margin-bottom: 0.55rem;
+  color: var(--bs-secondary-color);
+  font-size: 0.8rem;
+}
+
+.settings-item {
+  width: 100%;
+  border: 1px solid var(--bs-border-color);
+  border-radius: 0.75rem;
   background: var(--bs-body-bg);
+  color: var(--bs-body-color);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 0.85rem;
+  margin-bottom: 0.5rem;
+  transition: 0.2s ease;
 }
 
-.settings-tabs {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.5rem;
+.settings-item:hover {
+  background: var(--bs-tertiary-bg);
 }
 
-.settings-tab {
+.settings-item.active {
+  border-color: var(--bs-primary);
+  background: color-mix(in srgb, var(--bs-primary) 10%, var(--bs-body-bg));
+}
+
+.settings-item-start {
+  display: inline-flex;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.settings-item-arrow {
+  color: var(--bs-secondary-color);
+}
+
+.settings-detail-header {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  gap: 0.45rem;
-  border: 1px solid var(--bs-border-color);
-  border-radius: 0.7rem;
-  background: var(--bs-body-bg);
-  color: var(--bs-secondary-color);
-  padding: 0.6rem 0.75rem;
-}
-
-.settings-tab.active {
-  background: var(--bs-primary);
-  border-color: var(--bs-primary);
-  color: #fff;
-}
-
-.settings-pane {
-  min-height: 180px;
-}
-
-@media (max-width: 575.98px) {
-  .settings-tabs {
-    grid-template-columns: 1fr;
-  }
+  gap: 0.5rem;
+  padding: 0.45rem 0.7rem;
+  border-radius: 999px;
+  background: var(--bs-tertiary-bg);
 }
 </style>

--- a/src/views/settings/SettingsView.vue
+++ b/src/views/settings/SettingsView.vue
@@ -7,7 +7,7 @@ import {
   IconCloudDownload,
   IconDeviceMobileCog,
   IconMoonStars,
-  IconQuran,
+  IconBook2,
   IconSettings2,
   IconSunHigh,
 } from '@tabler/icons-vue'
@@ -82,7 +82,7 @@ const sectionLinks = [
 
           <section id="settings-downloads" class="settings-section">
             <div class="d-flex align-items-center gap-2 mb-2 text-muted small fw-semibold">
-              <IconQuran :size="16" />
+              <IconBook2 :size="16" />
               <span>المحتوى المحمّل</span>
             </div>
             <SettingsDownloadAssets />

--- a/src/views/settings/SettingsView.vue
+++ b/src/views/settings/SettingsView.vue
@@ -2,39 +2,140 @@
 import Page from '@/components/Layout/Page.vue'
 import Heading from '@/components/Heading.vue'
 
+import {
+  IconBell,
+  IconCloudDownload,
+  IconDeviceMobileCog,
+  IconMoonStars,
+  IconQuran,
+  IconSettings2,
+  IconSunHigh,
+} from '@tabler/icons-vue'
+
 import SettingsReciter from './partials/SettingsReciter.vue'
 import SettingsPrayerTimes from './partials/SettingsPrayerTimes.vue'
 import SettingsTheme from './partials/SettingsTheme.vue'
 import SettingsNotifications from './partials/SettingsNotifications.vue'
 import SettingsDownloadAssets from './partials/SettingsDownloadAssets.vue'
 import SettingsAppUpdates from './partials/SettingsAppUpdates.vue'
+
+const sectionLinks = [
+  { id: 'settings-general', label: 'عام', icon: IconSettings2 },
+  { id: 'settings-notifications', label: 'الإشعارات', icon: IconBell },
+  { id: 'settings-downloads', label: 'التحميلات', icon: IconCloudDownload },
+]
 </script>
 
 <template>
   <Page>
-    <Heading class="mb-4" title="الإعدادات" subtitle="تعديل الإعدادات المختلفة للتطبيق" />
+    <Heading class="mb-4" title="الإعدادات" subtitle="تخصيص التطبيق بطريقة مرتبة وسهلة" />
 
-    <div class="row g-3">
-      <div class="col-12 col-md-6">
-        <SettingsPrayerTimes />
+    <div class="row g-3 g-lg-4 align-items-start settings-layout">
+      <div class="col-12 col-lg-3">
+        <nav class="settings-nav card">
+          <div class="card-body py-2 px-2">
+            <a
+              v-for="section in sectionLinks"
+              :key="section.id"
+              class="settings-nav-link"
+              :href="`#${section.id}`"
+            >
+              <component :is="section.icon" :size="16" />
+              <span>{{ section.label }}</span>
+            </a>
+          </div>
+        </nav>
       </div>
-      <div class="col-12 col-md-6">
-        <SettingsReciter />
-      </div>
-      <div class="col-12 col-md-6">
-        <SettingsTheme />
-      </div>
-      <div class="col-12 col-md-6">
-        <SettingsAppUpdates />
-      </div>
-      <div class="col-12">
-        <SettingsNotifications />
-      </div>
-      <div class="col-12">
-        <SettingsDownloadAssets />
+
+      <div class="col-12 col-lg-9">
+        <div class="vstack gap-3 gap-lg-4">
+          <section id="settings-general" class="settings-section">
+            <div class="d-flex align-items-center gap-2 mb-2 text-muted small fw-semibold">
+              <IconDeviceMobileCog :size="16" />
+              <span>الإعدادات العامة</span>
+            </div>
+
+            <div class="row g-3">
+              <div class="col-12 col-xl-6">
+                <SettingsPrayerTimes />
+              </div>
+              <div class="col-12 col-xl-6">
+                <SettingsReciter />
+              </div>
+              <div class="col-12 col-xl-6">
+                <SettingsTheme />
+              </div>
+              <div class="col-12 col-xl-6">
+                <SettingsAppUpdates />
+              </div>
+            </div>
+          </section>
+
+          <section id="settings-notifications" class="settings-section">
+            <div class="d-flex align-items-center gap-2 mb-2 text-muted small fw-semibold">
+              <IconSunHigh :size="16" />
+              <IconMoonStars :size="16" />
+              <span>إشعارات الأذكار</span>
+            </div>
+            <SettingsNotifications />
+          </section>
+
+          <section id="settings-downloads" class="settings-section">
+            <div class="d-flex align-items-center gap-2 mb-2 text-muted small fw-semibold">
+              <IconQuran :size="16" />
+              <span>المحتوى المحمّل</span>
+            </div>
+            <SettingsDownloadAssets />
+          </section>
+        </div>
       </div>
     </div>
   </Page>
 </template>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.settings-layout {
+  scroll-margin-top: 1rem;
+}
+
+.settings-nav {
+  position: sticky;
+  top: 0.75rem;
+  overflow-x: auto;
+}
+
+.settings-nav .card-body {
+  display: flex;
+  gap: 0.5rem;
+
+  @media (min-width: 992px) {
+    flex-direction: column;
+  }
+}
+
+.settings-nav-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  padding: 0.55rem 0.75rem;
+  border: 1px solid var(--bs-border-color);
+  border-radius: 0.65rem;
+  text-decoration: none;
+  color: var(--bs-body-color);
+  white-space: nowrap;
+  background: var(--bs-body-bg);
+
+  &:hover {
+    background: var(--bs-tertiary-bg);
+  }
+
+  @media (min-width: 992px) {
+    justify-content: flex-start;
+  }
+}
+
+.settings-section {
+  scroll-margin-top: 1rem;
+}
+</style>

--- a/src/views/settings/SettingsView.vue
+++ b/src/views/settings/SettingsView.vue
@@ -1,16 +1,9 @@
 <script setup>
+import { ref } from 'vue'
 import Page from '@/components/Layout/Page.vue'
 import Heading from '@/components/Heading.vue'
 
-import {
-  IconBell,
-  IconCloudDownload,
-  IconDeviceMobileCog,
-  IconMoonStars,
-  IconBook2,
-  IconSettings2,
-  IconSunHigh,
-} from '@tabler/icons-vue'
+import { IconBell, IconCloudDownload, IconSettings } from '@tabler/icons-vue'
 
 import SettingsReciter from './partials/SettingsReciter.vue'
 import SettingsPrayerTimes from './partials/SettingsPrayerTimes.vue'
@@ -19,74 +12,60 @@ import SettingsNotifications from './partials/SettingsNotifications.vue'
 import SettingsDownloadAssets from './partials/SettingsDownloadAssets.vue'
 import SettingsAppUpdates from './partials/SettingsAppUpdates.vue'
 
-const sectionLinks = [
-  { id: 'settings-general', label: 'عام', icon: IconSettings2 },
-  { id: 'settings-notifications', label: 'الإشعارات', icon: IconBell },
-  { id: 'settings-downloads', label: 'التحميلات', icon: IconCloudDownload },
+const tabs = [
+  { id: 'general', label: 'عام', icon: IconSettings },
+  { id: 'notifications', label: 'الإشعارات', icon: IconBell },
+  { id: 'downloads', label: 'التحميلات', icon: IconCloudDownload },
 ]
+
+const activeTab = ref('general')
 </script>
 
 <template>
   <Page>
-    <Heading class="mb-4" title="الإعدادات" subtitle="تخصيص التطبيق بطريقة مرتبة وسهلة" />
+    <Heading class="mb-4" title="الإعدادات" subtitle="واجهة إعدادات مبسطة وسهلة الاستخدام" />
 
-    <div class="row g-3 g-lg-4 align-items-start settings-layout">
-      <div class="col-12 col-lg-3">
-        <nav class="settings-nav card">
-          <div class="card-body py-2 px-2">
-            <a
-              v-for="section in sectionLinks"
-              :key="section.id"
-              class="settings-nav-link"
-              :href="`#${section.id}`"
-            >
-              <component :is="section.icon" :size="16" />
-              <span>{{ section.label }}</span>
-            </a>
+    <div class="settings-shell card border-0 shadow-sm">
+      <div class="card-body p-2 p-md-3">
+        <div class="settings-tabs nav nav-pills mb-3" role="tablist" aria-label="أقسام الإعدادات">
+          <button
+            v-for="tab in tabs"
+            :key="tab.id"
+            class="nav-link settings-tab"
+            :class="{ active: activeTab === tab.id }"
+            type="button"
+            role="tab"
+            :aria-selected="activeTab === tab.id"
+            @click="activeTab = tab.id"
+          >
+            <component :is="tab.icon" :size="16" />
+            <span>{{ tab.label }}</span>
+          </button>
+        </div>
+
+        <div v-show="activeTab === 'general'" class="settings-pane" role="tabpanel">
+          <div class="row g-3">
+            <div class="col-12 col-xl-6">
+              <SettingsPrayerTimes />
+            </div>
+            <div class="col-12 col-xl-6">
+              <SettingsReciter />
+            </div>
+            <div class="col-12 col-xl-6">
+              <SettingsTheme />
+            </div>
+            <div class="col-12 col-xl-6">
+              <SettingsAppUpdates />
+            </div>
           </div>
-        </nav>
-      </div>
+        </div>
 
-      <div class="col-12 col-lg-9">
-        <div class="vstack gap-3 gap-lg-4">
-          <section id="settings-general" class="settings-section">
-            <div class="d-flex align-items-center gap-2 mb-2 text-muted small fw-semibold">
-              <IconDeviceMobileCog :size="16" />
-              <span>الإعدادات العامة</span>
-            </div>
+        <div v-show="activeTab === 'notifications'" class="settings-pane" role="tabpanel">
+          <SettingsNotifications />
+        </div>
 
-            <div class="row g-3">
-              <div class="col-12 col-xl-6">
-                <SettingsPrayerTimes />
-              </div>
-              <div class="col-12 col-xl-6">
-                <SettingsReciter />
-              </div>
-              <div class="col-12 col-xl-6">
-                <SettingsTheme />
-              </div>
-              <div class="col-12 col-xl-6">
-                <SettingsAppUpdates />
-              </div>
-            </div>
-          </section>
-
-          <section id="settings-notifications" class="settings-section">
-            <div class="d-flex align-items-center gap-2 mb-2 text-muted small fw-semibold">
-              <IconSunHigh :size="16" />
-              <IconMoonStars :size="16" />
-              <span>إشعارات الأذكار</span>
-            </div>
-            <SettingsNotifications />
-          </section>
-
-          <section id="settings-downloads" class="settings-section">
-            <div class="d-flex align-items-center gap-2 mb-2 text-muted small fw-semibold">
-              <IconBook2 :size="16" />
-              <span>المحتوى المحمّل</span>
-            </div>
-            <SettingsDownloadAssets />
-          </section>
+        <div v-show="activeTab === 'downloads'" class="settings-pane" role="tabpanel">
+          <SettingsDownloadAssets />
         </div>
       </div>
     </div>
@@ -94,48 +73,41 @@ const sectionLinks = [
 </template>
 
 <style lang="scss" scoped>
-.settings-layout {
-  scroll-margin-top: 1rem;
+.settings-shell {
+  background: var(--bs-body-bg);
 }
 
-.settings-nav {
-  position: sticky;
-  top: 0.75rem;
-  overflow-x: auto;
-}
-
-.settings-nav .card-body {
-  display: flex;
+.settings-tabs {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 0.5rem;
-
-  @media (min-width: 992px) {
-    flex-direction: column;
-  }
 }
 
-.settings-nav-link {
+.settings-tab {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 0.45rem;
-  padding: 0.55rem 0.75rem;
   border: 1px solid var(--bs-border-color);
-  border-radius: 0.65rem;
-  text-decoration: none;
-  color: var(--bs-body-color);
-  white-space: nowrap;
+  border-radius: 0.7rem;
   background: var(--bs-body-bg);
-
-  &:hover {
-    background: var(--bs-tertiary-bg);
-  }
-
-  @media (min-width: 992px) {
-    justify-content: flex-start;
-  }
+  color: var(--bs-secondary-color);
+  padding: 0.6rem 0.75rem;
 }
 
-.settings-section {
-  scroll-margin-top: 1rem;
+.settings-tab.active {
+  background: var(--bs-primary);
+  border-color: var(--bs-primary);
+  color: #fff;
+}
+
+.settings-pane {
+  min-height: 180px;
+}
+
+@media (max-width: 575.98px) {
+  .settings-tabs {
+    grid-template-columns: 1fr;
+  }
 }
 </style>


### PR DESCRIPTION
### Motivation
- The settings page was cluttered and needed clearer grouping to improve scanability and reduce visual noise.
- Provide a layout that works well on both mobile and desktop while keeping the app’s existing Bootstrap-based look and behavior.
- Keep existing setting components and stores intact and reuse them to avoid changing business logic.

### Description
- Replaced `src/views/settings/SettingsView.vue` with a reorganized view that groups related settings into anchored sections: `عام` (General), `الإشعارات` (Notifications), and `التحميلات` (Downloads). 
- Added a responsive in-page navigation card (horizontal on mobile, vertical/sticky on desktop) driven by a `sectionLinks` array and icons from `@tabler/icons-vue` to allow quick jumps to sections. 
- Kept existing partial components (`SettingsPrayerTimes`, `SettingsReciter`, `SettingsTheme`, `SettingsNotifications`, `SettingsDownloadAssets`, `SettingsAppUpdates`) and Bootstrap classes, only changing composition and placement for better hierarchy. 
- Added lightweight scoped SCSS for the settings layout and nav (`.settings-layout`, `.settings-nav`, `.settings-nav-link`, `.settings-section`) to preserve the app identity and responsiveness.

### Testing
- Ran `npm run lint`, which failed in this environment due to missing dev dependency: `Cannot find package 'eslint'`.
- Ran `npm run build`, which failed in this environment because `vite` is not available: `vite: not found`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccd368f700832b90ad4a4baf920276)