### PR TITLE
Add Hijri date display to home page

### DIFF
--- a/src/components/HijriDate.vue
+++ b/src/components/HijriDate.vue
@@ -1,0 +1,18 @@
+<script setup>
+import { computed } from 'vue'
+import { useNow } from '@vueuse/core'
+import { IconMoon } from '@tabler/icons-vue'
+import { formatHijriDate } from '@/utilities/arabic'
+
+// Refresh every minute so the date stays correct if the app is left open past midnight.
+const now = useNow({ interval: 60 * 1000 })
+
+const hijriDate = computed(() => formatHijriDate(now.value))
+</script>
+
+<template>
+  <div class="d-inline-flex align-items-center gap-2 text-secondary">
+    <IconMoon size="18" />
+    <span>{{ hijriDate }}</span>
+  </div>
+</template>

--- a/src/utilities/arabic.js
+++ b/src/utilities/arabic.js
@@ -33,6 +33,17 @@ export const toArabicNumerals = (value) => {
   return String(value).replace(/\d/g, (digit) => String.fromCharCode(0x660 + Number(digit)))
 }
 
+export const formatHijriDate = (date = new Date()) => {
+  // Use the Umm al-Qura calendar (the official Hijri calendar) localized in Arabic.
+  // This works fully offline and does not depend on the prayer times API.
+  return new Intl.DateTimeFormat('ar-SA-u-ca-islamic-umalqura', {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  }).format(date)
+}
+
 export const formatTime = (seconds) => {
   if (!seconds || seconds <= 0) return '٠٠:٠٠:٠٠'
   const h = Math.floor(seconds / 3600)

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,6 +1,7 @@
 <script setup>
 import Page from '@/components/Layout/Page.vue'
 import Heading from '@/components/Heading.vue'
+import HijriDate from '@/components/HijriDate.vue'
 import PrayerTimes from '@/components/PrayerTimes.vue'
 import RandomAyah from '@/components/RandomAyah.vue'
 import SunnahPrayers from '@/components/SunnahPrayers.vue'
@@ -12,7 +13,8 @@ const prayersStore = usePrayersStore()
 
 <template>
   <Page>
-    <Heading :size="2" class="mb-4" title="مواقيت الصلاة" subtitle="إن الصلاة كانت على المؤمنين كتابا موقوتا." />
+    <Heading :size="2" class="mb-2" title="مواقيت الصلاة" subtitle="إن الصلاة كانت على المؤمنين كتابا موقوتا." />
+    <HijriDate class="mb-4" />
     <PrayerTimes class="mb-5" :vertical="prayersStore.vertical" />
 
     <Heading :size="2" class="mb-4" title="السنن الرواتب" subtitle="وما يزال عبدي يتقرب إلي بالنوافل حتى أحبه." />


### PR DESCRIPTION
## Summary
Added a new Hijri date component to the home page that displays the current Islamic calendar date using the Umm al-Qura calendar standard.

## Key Changes
- **New Component**: Created `HijriDate.vue` component that displays the current Hijri date with a moon icon
  - Updates every minute to ensure accuracy if the app remains open past midnight
  - Uses Vue's `useNow` composable from `@vueuse/core`
  
- **New Utility Function**: Added `formatHijriDate()` to `src/utilities/arabic.js`
  - Leverages the native `Intl.DateTimeFormat` API with the `ar-SA-u-ca-islamic-umalqura` locale
  - Formats date with full weekday, day, month, and year in Arabic
  - Works completely offline without external API dependencies
  
- **Updated Home Page**: Integrated the new `HijriDate` component into `HomeView.vue`
  - Positioned below the main heading
  - Adjusted heading margin spacing for better layout

## Implementation Details
The Hijri date formatting uses the browser's built-in internationalization API with the Umm al-Qura calendar, which is the official Islamic calendar used in Saudi Arabia. This approach eliminates the need for external libraries or API calls while providing accurate, localized date formatting.

https://claude.ai/code/session_01FYzihBqreiLY8VsEqVjZ6N