### PR TITLE
Fix Android theme bar colors

### DIFF
--- a/src/utilities/css.js
+++ b/src/utilities/css.js
@@ -10,6 +10,18 @@ const PRIMARY_COLOR_VARS = [
 
 const BG_COLOR_VARS = ['--bs-body-bg', '--bs-body-bg-rgb', '--bs-secondary-bg', '--bs-tertiary-bg']
 
+function ensureMeta(name) {
+  let meta = document.querySelector(`meta[name="${name}"]`)
+
+  if (!meta) {
+    meta = document.createElement('meta')
+    meta.setAttribute('name', name)
+    document.head.appendChild(meta)
+  }
+
+  return meta
+}
+
 export function normalizeColor(value) {
   if (!value) return null
 
@@ -77,16 +89,16 @@ export function applyPrimaryColor(color) {
 }
 
 export function syncMetaThemeColor() {
-  const fg = getComputedStyle(document.documentElement).getPropertyValue('--bs-primary').trim()
-  const color = normalizeColor(fg)
-  if (!color) return
+  const styles = getComputedStyle(document.body)
+  const bg = normalizeColor(styles.backgroundColor || styles.getPropertyValue('--bs-body-bg'))
+  if (!bg) return
 
-  const metas = [
-    document.querySelector('meta[name="theme-color"]'),
-    document.querySelector('meta[name="msapplication-TileColor"]'),
-  ]
+  ensureMeta('theme-color').setAttribute('content', bg)
+  ensureMeta('msapplication-TileColor').setAttribute('content', bg)
 
-  metas.forEach((meta) => meta?.setAttribute('content', color))
+  const colorScheme = document.body.getAttribute('data-bs-theme') === 'dark' ? 'dark' : 'light'
+  ensureMeta('color-scheme').setAttribute('content', colorScheme)
+  document.documentElement.style.colorScheme = colorScheme
 }
 
 export function applyBgColor(color) {


### PR DESCRIPTION
### Motivation
- Mobile browsers and Android system bars were not following the app theme because the runtime `theme-color` meta was derived from the primary accent rather than the resolved page background. 
- Some meta tags required by PWAs / mobile browsers may be missing at runtime, causing updates to fail silently.

### Description
- Add an `ensureMeta` helper to create missing meta tags before updating them in `src/utilities/css.js`.
- Update `syncMetaThemeColor` to compute the actual resolved page background from `document.body` (or `--bs-body-bg`) and write that value to `theme-color` and `msapplication-TileColor` instead of the primary accent.
- Sync the document `color-scheme` (meta and `document.documentElement.style.colorScheme`) based on the active Bootstrap theme (`data-bs-theme`) so system UI can follow light/dark mode changes.

### Testing
- Ran `npm run build`, which completed successfully and produced the `dist` output. 
- Ran `npm run lint`, which failed due to existing ESLint parser errors for `.vue` files in the repository (unrelated to this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a318e43d994832b89ef0789c5c255ce)