### PR TITLE
Vibrate when zekr completes

### DIFF
--- a/src/components/ZekrCard.vue
+++ b/src/components/ZekrCard.vue
@@ -30,10 +30,20 @@ const emit = defineEmits(['increment', 'reset'])
 const count = ref(0)
 const isMobile = useMediaQuery('(max-width: 991.98px)')
 
+const vibrateOnFinish = () => {
+  if (typeof navigator !== 'undefined' && 'vibrate' in navigator) {
+    navigator.vibrate(200)
+  }
+}
+
 const increment = () => {
   if (count.value < props.repeat) {
     count.value++
     emit('increment')
+
+    if (count.value === props.repeat) {
+      vibrateOnFinish()
+    }
   }
 }
 

--- a/src/components/ZekrCard.vue
+++ b/src/components/ZekrCard.vue
@@ -1,10 +1,12 @@
 <script setup>
 import { ref } from 'vue'
+import { storeToRefs } from 'pinia'
 import { useMediaQuery } from '@vueuse/core'
 import { IconDownload, IconShare3, IconCopy, IconHeartShare, IconRestore } from '@tabler/icons-vue'
 import { exportComponent } from '@/utilities/export'
 import { toast } from 'vue-sonner'
 import { toArabicNumerals } from '@/utilities/arabic'
+import { useAppStore } from '@/stores/app'
 
 import ZekrImage from './ZekrImage.vue'
 
@@ -29,10 +31,12 @@ const emit = defineEmits(['increment', 'reset'])
 
 const count = ref(0)
 const isMobile = useMediaQuery('(max-width: 991.98px)')
+const appStore = useAppStore()
+const { zekrVibrationEnabled, zekrVibrationIntensity } = storeToRefs(appStore)
 
 const vibrateOnFinish = () => {
-  if (typeof navigator !== 'undefined' && 'vibrate' in navigator) {
-    navigator.vibrate(200)
+  if (zekrVibrationEnabled.value && typeof navigator !== 'undefined' && 'vibrate' in navigator) {
+    navigator.vibrate(zekrVibrationIntensity.value)
   }
 }
 

--- a/src/stores/app.js
+++ b/src/stores/app.js
@@ -3,8 +3,16 @@ import { useLocalStorage } from '@vueuse/core'
 
 export const useAppStore = defineStore('app', () => {
   const autoUpdateServiceWorker = useLocalStorage('auto-update-service-worker', true)
+  const zekrVibrationEnabled = useLocalStorage('zekr-vibration-enabled', true)
+  const zekrVibrationIntensity = useLocalStorage('zekr-vibration-intensity', 60)
+
+  if (!Number.isFinite(zekrVibrationIntensity.value)) {
+    zekrVibrationIntensity.value = 60
+  }
 
   return {
     autoUpdateServiceWorker,
+    zekrVibrationEnabled,
+    zekrVibrationIntensity,
   }
 })

--- a/src/views/settings/SettingsView.vue
+++ b/src/views/settings/SettingsView.vue
@@ -8,6 +8,7 @@ import SettingsTheme from './partials/SettingsTheme.vue'
 import SettingsNotifications from './partials/SettingsNotifications.vue'
 import SettingsDownloadAssets from './partials/SettingsDownloadAssets.vue'
 import SettingsAppUpdates from './partials/SettingsAppUpdates.vue'
+import SettingsZekr from './partials/SettingsZekr.vue'
 </script>
 
 <template>
@@ -26,6 +27,9 @@ import SettingsAppUpdates from './partials/SettingsAppUpdates.vue'
       </div>
       <div class="col-12 col-md-6">
         <SettingsAppUpdates />
+      </div>
+      <div class="col-12 col-md-6">
+        <SettingsZekr />
       </div>
       <div class="col-12">
         <SettingsNotifications />

--- a/src/views/settings/partials/SettingsZekr.vue
+++ b/src/views/settings/partials/SettingsZekr.vue
@@ -1,0 +1,55 @@
+<script setup>
+import { computed } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useAppStore } from '@/stores/app'
+import { toArabicNumerals } from '@/utilities/arabic'
+
+const appStore = useAppStore()
+const { zekrVibrationEnabled, zekrVibrationIntensity } = storeToRefs(appStore)
+
+const vibrationValueLabel = computed(() => toArabicNumerals(String(zekrVibrationIntensity.value)))
+</script>
+
+<template>
+  <div class="card h-100">
+    <div class="card-body">
+      <h6 class="card-title mb-3">الأذكار</h6>
+      <p class="card-text text-muted mb-3">التحكم في الاهتزاز عند الانتهاء من تكرار الذكر.</p>
+
+      <div class="p-3 border rounded">
+        <div class="d-flex justify-content-between align-items-center gap-3 flex-wrap mb-3">
+          <div>
+            <div class="fw-medium">الاهتزاز عند الانتهاء</div>
+            <small class="text-muted">يعمل على الأجهزة والمتصفحات التي تدعم الاهتزاز.</small>
+          </div>
+          <div class="form-check form-switch m-0">
+            <input id="swZekrVibration" v-model="zekrVibrationEnabled" class="form-check-input" type="checkbox" />
+          </div>
+        </div>
+
+        <div>
+          <div class="d-flex justify-content-between align-items-center gap-3 mb-2">
+            <span>قوة الاهتزاز</span>
+            <small class="text-muted">{{ vibrationValueLabel }} مللي ثانية</small>
+          </div>
+
+          <input
+            id="zekrVibrationIntensity"
+            v-model.number="zekrVibrationIntensity"
+            class="form-range"
+            type="range"
+            min="20"
+            max="250"
+            step="10"
+            :disabled="!zekrVibrationEnabled"
+          />
+
+          <div class="d-flex justify-content-between text-muted">
+            <small>خفيف</small>
+            <small>قوي</small>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
### Motivation
- Provide haptic feedback to the user when a zekr counter reaches its configured repeat so the user knows the zikr is finished.

### Description
- Add a guarded `vibrateOnFinish` helper and call in `src/components/ZekrCard.vue` that invokes `navigator.vibrate(200)` only when `typeof navigator !== 'undefined' && 'vibrate' in navigator`, and trigger it when `count.value === props.repeat`.

### Testing
- Ran `npm run build` which completed successfully, ran `git diff --check` with no errors, and ran `npm run lint` which failed due to existing Vue SFC parsing errors across the project (unrelated to this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31eedd3de4832bb7016f47c62c9901)