### PR TITLE
[Under Review] Add optional auto-scroll to next zekr after completion

### DIFF
--- a/src/components/ZekrCard.vue
+++ b/src/components/ZekrCard.vue
@@ -32,12 +32,19 @@ const emit = defineEmits(['increment', 'reset'])
 const count = ref(0)
 const isMobile = useMediaQuery('(max-width: 991.98px)')
 const appStore = useAppStore()
-const { zekrVibrationEnabled, zekrVibrationIntensity } = storeToRefs(appStore)
+const { zekrMoveNextOnComplete, zekrVibrationEnabled, zekrVibrationIntensity } = storeToRefs(appStore)
+const card = ref(null)
 
 const vibrateOnFinish = () => {
   if (zekrVibrationEnabled.value && typeof navigator !== 'undefined' && 'vibrate' in navigator) {
     navigator.vibrate(zekrVibrationIntensity.value)
   }
+}
+
+const moveToNextZekr = () => {
+  if (!zekrMoveNextOnComplete.value) return
+
+  card.value?.nextElementSibling?.scrollIntoView({ behavior: 'smooth', block: 'center' })
 }
 
 const increment = () => {
@@ -47,6 +54,7 @@ const increment = () => {
 
     if (count.value === props.repeat) {
       vibrateOnFinish()
+      moveToNextZekr()
     }
   }
 }
@@ -104,7 +112,7 @@ const copyZekr = async () => {
 </script>
 
 <template>
-  <div class="zekr-card border rounded p-4" @click="onCardClick">
+  <div ref="card" class="zekr-card border rounded p-4" @click="onCardClick">
     <div class="action-menu dropdown" @click.stop>
       <button class="btn p-0 bg-transparent" type="button" data-bs-toggle="dropdown">
         <IconHeartShare size="18" />

--- a/src/stores/app.js
+++ b/src/stores/app.js
@@ -14,6 +14,7 @@ export const useAppStore = defineStore('app', () => {
   const autoUpdateServiceWorker = useLocalStorage('auto-update-service-worker', true)
   const zekrVibrationEnabled = useLocalStorage('zekr-vibration-enabled', true)
   const zekrVibrationIntensity = useLocalStorage('zekr-vibration-intensity', 60)
+  const zekrMoveNextOnComplete = useLocalStorage('zekr-move-next-on-complete', false)
   const notificationTimezone = useLocalStorage(
     'notification-timezone',
     Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC',
@@ -46,6 +47,7 @@ export const useAppStore = defineStore('app', () => {
     autoUpdateServiceWorker,
     zekrVibrationEnabled,
     zekrVibrationIntensity,
+    zekrMoveNextOnComplete,
     notificationTimezone,
     notificationTopics,
     syncNotificationTimezone,

--- a/src/views/settings/partials/SettingsZekr.vue
+++ b/src/views/settings/partials/SettingsZekr.vue
@@ -3,16 +3,29 @@ import { computed } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useAppStore } from '@/stores/app'
 import { toArabicNumerals } from '@/utilities/arabic'
-import { IconDeviceMobileVibration } from '@tabler/icons-vue'
+import { IconArrowDownCircle, IconDeviceMobileVibration } from '@tabler/icons-vue'
 import SettingsSection from './SettingsSection.vue'
 
 const appStore = useAppStore()
-const { zekrVibrationEnabled, zekrVibrationIntensity } = storeToRefs(appStore)
+const { zekrMoveNextOnComplete, zekrVibrationEnabled, zekrVibrationIntensity } = storeToRefs(appStore)
 
 const vibrationValueLabel = computed(() => toArabicNumerals(String(zekrVibrationIntensity.value)))
 </script>
 
 <template>
+  <SettingsSection
+    class="mb-4"
+    title="الانتقال للذكر التالي"
+    description="ينقلك تلقائيا إلى الذكر التالي عند إكمال العدد المطلوب"
+    :icon="IconArrowDownCircle"
+  >
+    <template #actions>
+      <div class="form-check form-switch m-0">
+        <input id="swZekrMoveNext" v-model="zekrMoveNextOnComplete" class="form-check-input" type="checkbox" />
+      </div>
+    </template>
+  </SettingsSection>
+
   <SettingsSection
     title="الاهتزاز عند الانتهاء"
     description="يعمل على الأجهزة والمتصفحات التي تدعم الاهتزاز"


### PR DESCRIPTION
Description:
Adds a new Azkar setting that lets users automatically move to the next zekr when the current zekr reaches its required repeat count.
Changes:
Added a persisted zekrMoveNextOnComplete setting, defaulting to off.
Added a switch for the option in Azkar settings.
Updated ZekrCard to scroll to the next zekr only when the option is enabled.