### PR TITLE
feat(settings): render reciter card form-only inside quran player sheet

### DIFF
--- a/src/features/quran/components/QuranPlayer.vue
+++ b/src/features/quran/components/QuranPlayer.vue
@@ -1,11 +1,15 @@
 <script setup>
-import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted, provide } from 'vue'
 import { useQuranStore } from '@/features/quran/store'
 import { useRadioStore } from '@/features/radio/store'
 import { IconPlayerPlay, IconPlayerPause, IconMicrophone2 } from '@tabler/icons-vue'
 import { toArabicNumerals, formatTime } from '@/shared/utils/arabic'
 import BottomSheet from '@/shared/ui/BottomSheet.vue'
 import SettingsReciter from '@/features/settings/components/SettingsReciter.vue'
+
+// Render settings cards (the reciter picker) form-only inside the sheet — the
+// sheet provides its own title, so the card chrome would be redundant.
+provide('settings-bare', true)
 
 const quranStore = useQuranStore()
 const radioStore = useRadioStore()

--- a/src/features/settings/components/SettingsSection.vue
+++ b/src/features/settings/components/SettingsSection.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { Comment, Text, computed, useSlots } from 'vue'
+import { Comment, Text, computed, useSlots, inject } from 'vue'
 
 defineProps({
   title: { type: String, default: '' },
@@ -8,6 +8,11 @@ defineProps({
 })
 
 const slots = useSlots()
+
+// When rendered inside a "bare" context (e.g. a bottom sheet that supplies its
+// own title/chrome) drop the card + header and render only the form body. Any
+// SettingsSection-based card opts in automatically — no per-card changes.
+const bare = inject('settings-bare', false)
 
 // Whether the default slot renders anything meaningful (so we can drop the
 // body wrapper entirely for header-only cards instead of leaving a gap).
@@ -22,7 +27,11 @@ const hasBody = computed(() => {
 </script>
 
 <template>
-  <section class="settings-section card h-100">
+  <div v-if="bare" class="settings-section-body">
+    <slot />
+  </div>
+
+  <section v-else class="settings-section card h-100">
     <div class="card-body">
       <header v-if="title || $slots.actions" class="settings-section-header" :class="{ 'is-flush': !hasBody }">
         <div class="settings-section-heading">


### PR DESCRIPTION
Add a generic "bare" rendering mode to SettingsSection via provide/inject.
Any SettingsSection-based card automatically drops its card + header chrome
when an ancestor provides SETTINGS_SECTION_BARE, rendering only the form body.

QuranPlayer provides the flag so the reciter picker shows just the form inside
the bottom sheet (which supplies its own title) — no changes to the individual
settings cards.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PqNrxSbJtrFWrog6G4CzPp