### PR TITLE
feat(azkar): persist per-category zekr progress

### DIFF
--- a/src/app/router/index.js
+++ b/src/app/router/index.js
@@ -15,6 +15,14 @@ function withEmbedAliases(routes) {
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
+  // Let vue-router own scrolling (it also switches the browser to manual scroll
+  // restoration). Running only after a confirmed navigation means a cancelled
+  // leave-guard — e.g. the azkar "lm tnth bʿd" sheet on browser/gesture back —
+  // no longer yanks the page to the top while the sheet is open.
+  scrollBehavior(to, from, savedPosition) {
+    if (savedPosition) return savedPosition
+    return { top: 0, behavior: 'smooth' }
+  },
   routes: withEmbedAliases([
     {
       path: '/',
@@ -171,9 +179,6 @@ router.afterEach((to) => {
 
   // Stop the progress bar
   nProgress.done()
-
-  // Scroll to the top of the page smoothly
-  window.scrollTo({ top: 0, behavior: 'smooth' })
 
   // Update the meta tags
   useMeta(to.meta)

--- a/src/app/router/index.js
+++ b/src/app/router/index.js
@@ -15,10 +15,8 @@ function withEmbedAliases(routes) {
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
-  // Let vue-router own scrolling (it also switches the browser to manual scroll
-  // restoration). Running only after a confirmed navigation means a cancelled
-  // leave-guard — e.g. the azkar "lm tnth bʿd" sheet on browser/gesture back —
-  // no longer yanks the page to the top while the sheet is open.
+  // Owns scrolling so a cancelled leave-guard on browser back no longer yanks
+  // the page to the top (also switches the browser to manual restoration).
   scrollBehavior(to, from, savedPosition) {
     if (savedPosition) return savedPosition
     return { top: 0, behavior: 'smooth' }

--- a/src/features/azkar/components/ZekrCard.vue
+++ b/src/features/azkar/components/ZekrCard.vue
@@ -27,9 +27,8 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits(['increment', 'reset'])
+const count = defineModel('count', { type: Number, default: 0 })
 
-const count = ref(0)
 const card = ref(null)
 const isMobile = useIsMobile()
 const { vibrateOnFinish } = useZekrVibration()
@@ -38,7 +37,6 @@ const { scrollToNextZekr } = useZekrScroll(card)
 const increment = () => {
   if (count.value < props.repeat) {
     count.value++
-    emit('increment')
 
     if (count.value === props.repeat) {
       vibrateOnFinish()
@@ -48,10 +46,7 @@ const increment = () => {
 }
 
 const reset = () => {
-  if (count.value > 0) {
-    emit('reset', count.value)
-    count.value = 0
-  }
+  if (count.value > 0) count.value = 0
 }
 
 const onCardClick = () => {

--- a/src/features/azkar/composables/useAzkarProgress.js
+++ b/src/features/azkar/composables/useAzkarProgress.js
@@ -1,0 +1,28 @@
+import { useLocalStorage } from '@vueuse/core'
+import { computed, toValue } from 'vue'
+import { STORAGE_KEYS } from '@/shared/constants/storageKeys'
+
+// Persisted map of category slug -> array of per-zekr counts, so a user can
+// leave a category (or reload the page) and resume their azkar where they
+// stopped. Defined at module scope so every caller shares one reactive source.
+const store = useLocalStorage(STORAGE_KEYS.azkarProgress, {})
+
+export const useAzkarProgress = (slug) => {
+  const counts = computed(() => store.value[toValue(slug)] ?? [])
+
+  const getCount = (index) => counts.value[index] ?? 0
+
+  const setCount = (index, value) => {
+    const next = [...counts.value]
+    next[index] = value
+    store.value = { ...store.value, [toValue(slug)]: next }
+  }
+
+  const clear = () => {
+    const next = { ...store.value }
+    delete next[toValue(slug)]
+    store.value = next
+  }
+
+  return { counts, getCount, setCount, clear }
+}

--- a/src/features/azkar/composables/useAzkarProgress.js
+++ b/src/features/azkar/composables/useAzkarProgress.js
@@ -21,7 +21,7 @@ export const useAzkarProgress = (slug) => {
 
   sync()
 
-  const counts = computed(() => (store.value.date === today() ? store.value.categories[toValue(slug)] ?? [] : []))
+  const counts = computed(() => (store.value.date === today() ? (store.value.categories[toValue(slug)] ?? []) : []))
 
   const getCount = (index) => counts.value[index] ?? 0
 

--- a/src/features/azkar/composables/useAzkarProgress.js
+++ b/src/features/azkar/composables/useAzkarProgress.js
@@ -2,26 +2,40 @@ import { useLocalStorage } from '@vueuse/core'
 import { computed, toValue } from 'vue'
 import { STORAGE_KEYS } from '@/shared/constants/storageKeys'
 
-// Persisted map of category slug -> array of per-zekr counts, so a user can
-// leave a category (or reload the page) and resume their azkar where they
-// stopped. Defined at module scope so every caller shares one reactive source.
-const store = useLocalStorage(STORAGE_KEYS.azkarProgress, {})
+// Persisted daily azkar progress: a date stamp plus a map of category slug ->
+// array of per-zekr counts. Azkar are read fresh every day, so the whole
+// store resets automatically once the local date rolls over. Defined at module
+// scope so every caller shares one reactive source.
+const store = useLocalStorage(STORAGE_KEYS.azkarProgress, { date: '', categories: {} })
+
+// Local calendar day as YYYY-MM-DD (en-CA yields that ISO-like format).
+const today = () => new Date().toLocaleDateString('en-CA')
 
 export const useAzkarProgress = (slug) => {
-  const counts = computed(() => store.value[toValue(slug)] ?? [])
+  // Drop yesterday's progress as soon as a new day starts.
+  const sync = () => {
+    if (store.value.date !== today()) {
+      store.value = { date: today(), categories: {} }
+    }
+  }
+
+  sync()
+
+  const counts = computed(() => (store.value.date === today() ? store.value.categories[toValue(slug)] ?? [] : []))
 
   const getCount = (index) => counts.value[index] ?? 0
 
   const setCount = (index, value) => {
+    sync()
     const next = [...counts.value]
     next[index] = value
-    store.value = { ...store.value, [toValue(slug)]: next }
+    store.value = { date: today(), categories: { ...store.value.categories, [toValue(slug)]: next } }
   }
 
   const clear = () => {
-    const next = { ...store.value }
-    delete next[toValue(slug)]
-    store.value = next
+    const categories = { ...store.value.categories }
+    delete categories[toValue(slug)]
+    store.value = { ...store.value, categories }
   }
 
   return { counts, getCount, setCount, clear }

--- a/src/features/azkar/composables/useAzkarProgress.js
+++ b/src/features/azkar/composables/useAzkarProgress.js
@@ -2,17 +2,14 @@ import { useLocalStorage } from '@vueuse/core'
 import { computed, toValue } from 'vue'
 import { STORAGE_KEYS } from '@/shared/constants/storageKeys'
 
-// Persisted daily azkar progress: a date stamp plus a map of category slug ->
-// array of per-zekr counts. Azkar are read fresh every day, so the whole
-// store resets automatically once the local date rolls over. Defined at module
-// scope so every caller shares one reactive source.
+// Daily azkar progress: a date stamp plus a map of slug -> per-zekr counts,
+// shared module-wide so every caller reads one reactive source.
 const store = useLocalStorage(STORAGE_KEYS.azkarProgress, { date: '', categories: {} })
 
-// Local calendar day as YYYY-MM-DD (en-CA yields that ISO-like format).
 const today = () => new Date().toLocaleDateString('en-CA')
 
 export const useAzkarProgress = (slug) => {
-  // Drop yesterday's progress as soon as a new day starts.
+  // Drop yesterday's progress once a new day starts.
   const sync = () => {
     if (store.value.date !== today()) {
       store.value = { date: today(), categories: {} }

--- a/src/features/azkar/views/AzkarCategoryView.vue
+++ b/src/features/azkar/views/AzkarCategoryView.vue
@@ -1,9 +1,9 @@
 <script setup>
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { onBeforeRouteLeave } from 'vue-router'
 import { useConfirmDialog } from '@vueuse/core'
 import { useRouteParams } from '@vueuse/router'
-import { IconDoorExit, IconArrowBackUp } from '@tabler/icons-vue'
+import { IconDoorExit, IconArrowBackUp, IconRestore } from '@tabler/icons-vue'
 
 import Page from '@/layout/Page.vue'
 import Heading from '@/shared/ui/Heading.vue'
@@ -42,8 +42,17 @@ const totalClicked = computed(
 )
 const progress = computed(() => (totalRepeats.value > 0 ? (totalClicked.value / totalRepeats.value) * 100 : 0))
 
+const hasProgress = computed(() => totalClicked.value > 0)
 const isComplete = () => progress.value >= 100
 const hasUnfinishedProgress = () => progress.value > 0 && !isComplete()
+
+// Manual reset of the current category's progress
+const isResetRevealed = ref(false)
+
+const resetProgress = () => {
+  clear()
+  isResetRevealed.value = false
+}
 
 // Confirm dialog before leaving
 const { isRevealed, reveal, confirm, cancel } = useConfirmDialog()
@@ -79,8 +88,12 @@ onBeforeRouteLeave(async () => {
         @update:count="setCount(index, $event)"
       />
 
-      <div class="d-flex justify-content-center">
+      <div class="d-flex justify-content-center gap-2">
         <BackButton :to="{ name: 'azkar' }" button-class="btn-primary" />
+        <button v-if="hasProgress" class="btn btn-outline-secondary" type="button" @click="isResetRevealed = true">
+          <IconRestore size="18" class="me-1" />
+          <span>تصفير التقدم</span>
+        </button>
       </div>
     </Page>
   </AsyncContent>
@@ -99,6 +112,25 @@ onBeforeRouteLeave(async () => {
         <button class="bottom-sheet-item text-danger" @click="confirm">
           <IconDoorExit size="20" />
           <span>مغادرة</span>
+        </button>
+      </li>
+    </ul>
+  </BottomSheet>
+
+  <!-- Reset confirmation sheet -->
+  <BottomSheet :show="isResetRevealed" title="تصفير التقدم" @close="isResetRevealed = false">
+    <p class="px-4 pt-3 mb-2 lh-lg text-secondary">سيتم تصفير تقدمك في هذه الأذكار، هل أنت متأكد؟</p>
+    <ul class="list-unstyled m-0 py-2">
+      <li>
+        <button class="bottom-sheet-item" @click="isResetRevealed = false">
+          <IconArrowBackUp size="20" />
+          <span>تراجع</span>
+        </button>
+      </li>
+      <li>
+        <button class="bottom-sheet-item text-danger" @click="resetProgress">
+          <IconRestore size="20" />
+          <span>تصفير</span>
         </button>
       </li>
     </ul>

--- a/src/features/azkar/views/AzkarCategoryView.vue
+++ b/src/features/azkar/views/AzkarCategoryView.vue
@@ -29,12 +29,9 @@ usePageMeta(
     },
 )
 
-// Per-zekr counts persisted in localStorage so progress survives reloads and
-// navigating away, letting the user resume the category where they stopped.
 const { getCount, setCount, clear } = useAzkarProgress(slug)
 
-// Track progress across all azkar (clamped in case a stored count outlives a
-// change to a zekr's repeat target).
+// Clamped in case a stored count outlives a change to a zekr's repeat target.
 const clampedCount = (index, repeat) => Math.min(getCount(index), repeat || 1)
 const totalRepeats = computed(() => category.value?.content?.reduce((sum, z) => sum + (z.repeat || 1), 0) || 0)
 const totalClicked = computed(
@@ -44,8 +41,6 @@ const progress = computed(() => (totalRepeats.value > 0 ? (totalClicked.value / 
 
 const hasProgress = computed(() => totalClicked.value > 0)
 
-// Confirm before leaving with unfinished azkar; clear a finished category so
-// the next visit starts fresh.
 const { isRevealed, reveal, confirm, cancel } = useConfirmDialog()
 
 onBeforeRouteLeave(async () => {

--- a/src/features/azkar/views/AzkarCategoryView.vue
+++ b/src/features/azkar/views/AzkarCategoryView.vue
@@ -60,7 +60,19 @@ onBeforeRouteLeave(async () => {
 <template>
   <AsyncContent :pending="isFetching" :error="error" loading-message="جاري تحميل الأذكار...">
     <Page v-if="category">
-      <Heading class="mb-4" :title="category.meta.name" :subtitle="category.meta.description" :share="true" />
+      <div class="d-flex align-items-start justify-content-between gap-2 mb-4">
+        <Heading :title="category.meta.name" :subtitle="category.meta.description" :share="true" />
+
+        <button
+          v-if="hasProgress"
+          class="btn btn-light text-danger flex-shrink-0 d-inline-flex align-items-center gap-1"
+          type="button"
+          @click="clear"
+        >
+          <IconRestore size="18" />
+          <span>تصفير</span>
+        </button>
+      </div>
 
       <ZekrCard
         class="mb-3"
@@ -74,12 +86,8 @@ onBeforeRouteLeave(async () => {
         @update:count="setCount(index, $event)"
       />
 
-      <div class="d-flex justify-content-center gap-2">
+      <div class="d-flex justify-content-center">
         <BackButton :to="{ name: 'azkar' }" button-class="btn-primary" />
-        <button v-if="hasProgress" class="btn btn-outline-secondary" type="button" @click="clear">
-          <IconRestore size="18" class="me-1" />
-          <span>تصفير التقدم</span>
-        </button>
       </div>
     </Page>
   </AsyncContent>

--- a/src/features/azkar/views/AzkarCategoryView.vue
+++ b/src/features/azkar/views/AzkarCategoryView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed } from 'vue'
+import { computed } from 'vue'
 import { onBeforeRouteLeave } from 'vue-router'
 import { useConfirmDialog } from '@vueuse/core'
 import { useRouteParams } from '@vueuse/router'
@@ -13,6 +13,7 @@ import BottomSheet from '@/shared/ui/BottomSheet.vue'
 import ZekrCard from '@/features/azkar/components/ZekrCard.vue'
 import { useAsyncData } from '@/shared/composables/useAsyncData'
 import { usePageMeta } from '@/shared/composables/usePageMeta'
+import { useAzkarProgress } from '@/features/azkar/composables/useAzkarProgress'
 import { fetchCategory } from '@/features/azkar/api'
 
 const slug = useRouteParams('category')
@@ -28,17 +29,32 @@ usePageMeta(
     },
 )
 
-// Track progress across all azkar
-const totalClicked = ref(0)
+// Per-zekr counts persisted in localStorage so progress survives reloads and
+// navigating away, letting the user resume the category where they stopped.
+const { getCount, setCount, clear } = useAzkarProgress(slug)
+
+// Track progress across all azkar (clamped in case a stored count outlives a
+// change to a zekr's repeat target).
+const clampedCount = (index, repeat) => Math.min(getCount(index), repeat || 1)
 const totalRepeats = computed(() => category.value?.content?.reduce((sum, z) => sum + (z.repeat || 1), 0) || 0)
+const totalClicked = computed(
+  () => category.value?.content?.reduce((sum, z, i) => sum + clampedCount(i, z.repeat), 0) || 0,
+)
 const progress = computed(() => (totalRepeats.value > 0 ? (totalClicked.value / totalRepeats.value) * 100 : 0))
 
-const hasUnfinishedProgress = () => progress.value > 0 && progress.value < 100
+const isComplete = () => progress.value >= 100
+const hasUnfinishedProgress = () => progress.value > 0 && !isComplete()
 
 // Confirm dialog before leaving
 const { isRevealed, reveal, confirm, cancel } = useConfirmDialog()
 
 onBeforeRouteLeave(async () => {
+  // Clear a finished category so the next visit starts fresh.
+  if (isComplete()) {
+    clear()
+    return true
+  }
+
   if (!hasUnfinishedProgress()) return true
 
   const { isCanceled } = await reveal()
@@ -59,8 +75,8 @@ onBeforeRouteLeave(async () => {
         :repeat="zekr.repeat"
         :reference="zekr.reference"
         :benefit="zekr.benefit"
-        @increment="totalClicked++"
-        @reset="totalClicked -= $event"
+        :count="clampedCount(index, zekr.repeat)"
+        @update:count="setCount(index, $event)"
       />
 
       <div class="d-flex justify-content-center">

--- a/src/features/azkar/views/AzkarCategoryView.vue
+++ b/src/features/azkar/views/AzkarCategoryView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 import { onBeforeRouteLeave } from 'vue-router'
 import { useConfirmDialog } from '@vueuse/core'
 import { useRouteParams } from '@vueuse/router'
@@ -43,28 +43,14 @@ const totalClicked = computed(
 const progress = computed(() => (totalRepeats.value > 0 ? (totalClicked.value / totalRepeats.value) * 100 : 0))
 
 const hasProgress = computed(() => totalClicked.value > 0)
-const isComplete = () => progress.value >= 100
-const hasUnfinishedProgress = () => progress.value > 0 && !isComplete()
 
-// Manual reset of the current category's progress
-const isResetRevealed = ref(false)
-
-const resetProgress = () => {
-  clear()
-  isResetRevealed.value = false
-}
-
-// Confirm dialog before leaving
+// Confirm before leaving with unfinished azkar; clear a finished category so
+// the next visit starts fresh.
 const { isRevealed, reveal, confirm, cancel } = useConfirmDialog()
 
 onBeforeRouteLeave(async () => {
-  // Clear a finished category so the next visit starts fresh.
-  if (isComplete()) {
-    clear()
-    return true
-  }
-
-  if (!hasUnfinishedProgress()) return true
+  if (progress.value >= 100) clear()
+  if (progress.value <= 0 || progress.value >= 100) return true
 
   const { isCanceled } = await reveal()
   return !isCanceled
@@ -90,7 +76,7 @@ onBeforeRouteLeave(async () => {
 
       <div class="d-flex justify-content-center gap-2">
         <BackButton :to="{ name: 'azkar' }" button-class="btn-primary" />
-        <button v-if="hasProgress" class="btn btn-outline-secondary" type="button" @click="isResetRevealed = true">
+        <button v-if="hasProgress" class="btn btn-outline-secondary" type="button" @click="clear">
           <IconRestore size="18" class="me-1" />
           <span>تصفير التقدم</span>
         </button>
@@ -112,25 +98,6 @@ onBeforeRouteLeave(async () => {
         <button class="bottom-sheet-item text-danger" @click="confirm">
           <IconDoorExit size="20" />
           <span>مغادرة</span>
-        </button>
-      </li>
-    </ul>
-  </BottomSheet>
-
-  <!-- Reset confirmation sheet -->
-  <BottomSheet :show="isResetRevealed" title="تصفير التقدم" @close="isResetRevealed = false">
-    <p class="px-4 pt-3 mb-2 lh-lg text-secondary">سيتم تصفير تقدمك في هذه الأذكار، هل أنت متأكد؟</p>
-    <ul class="list-unstyled m-0 py-2">
-      <li>
-        <button class="bottom-sheet-item" @click="isResetRevealed = false">
-          <IconArrowBackUp size="20" />
-          <span>تراجع</span>
-        </button>
-      </li>
-      <li>
-        <button class="bottom-sheet-item text-danger" @click="resetProgress">
-          <IconRestore size="20" />
-          <span>تصفير</span>
         </button>
       </li>
     </ul>

--- a/src/shared/constants/storageKeys.js
+++ b/src/shared/constants/storageKeys.js
@@ -5,6 +5,7 @@ export const STORAGE_KEYS = {
   zekrVibrationEnabled: 'zekr-vibration-enabled',
   zekrVibrationIntensity: 'zekr-vibration-intensity',
   zekrMoveNextOnComplete: 'zekr-move-next-on-complete',
+  azkarProgress: 'azkar-progress',
 
   themeMode: 'mode',
   themePrimary: 'theme-primary',


### PR DESCRIPTION
Store each category's per-zekr counts in localStorage so progress
survives reloads and navigating away, letting users resume where they
stopped. Counts are lifted into the category view via a v-model on
ZekrCard and cleared once a category is fully completed.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01REDDVuP7UbJbB7qDAYosg5