### PR TITLE
Add Quran ayah bookmarking

### DIFF
--- a/src/features/quran/components/AyahActionSheet.vue
+++ b/src/features/quran/components/AyahActionSheet.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { computed } from 'vue'
 import { toast } from 'vue-sonner'
-import { IconPlayerPlay, IconBook2, IconCopy, IconShare3 } from '@tabler/icons-vue'
+import { IconPlayerPlay, IconBook2, IconCopy, IconShare3, IconBookmark, IconBookmarkOff } from '@tabler/icons-vue'
 import { toArabicNumerals } from '@/shared/utils/arabic'
 import BottomSheet from '@/shared/ui/BottomSheet.vue'
 
@@ -9,9 +9,10 @@ const props = defineProps({
   ayah: { type: Object, default: null },
   surahName: { type: String, default: '' },
   online: { type: Boolean, default: true },
+  bookmarked: { type: Boolean, default: false },
 })
 
-const emit = defineEmits(['recite', 'tafseer', 'close'])
+const emit = defineEmits(['recite', 'tafseer', 'bookmark', 'close'])
 
 const title = computed(() => (props.ayah ? `${props.surahName} ${toArabicNumerals(props.ayah.numberInSurah)}` : ''))
 const shareText = computed(() => (props.ayah ? `${props.ayah.text}\n[${title.value}]` : ''))
@@ -56,6 +57,12 @@ const share = () => {
         <button class="bottom-sheet-item" @click="emitAndClose('tafseer')">
           <IconBook2 size="20" />
           <span>تفسير</span>
+        </button>
+      </li>
+      <li>
+        <button class="bottom-sheet-item" @click="emitAndClose('bookmark')">
+          <component :is="bookmarked ? IconBookmarkOff : IconBookmark" size="20" />
+          <span>{{ bookmarked ? 'إزالة الإشارة المرجعية' : 'تعيين كإشارة مرجعية' }}</span>
         </button>
       </li>
       <li><hr class="my-2" /></li>

--- a/src/features/quran/composables/useQuranBookmark.js
+++ b/src/features/quran/composables/useQuranBookmark.js
@@ -1,0 +1,49 @@
+import { useLocalStorage } from '@vueuse/core'
+import { STORAGE_KEYS } from '@/shared/constants/storageKeys'
+
+// useLocalStorage's default serializer can't round-trip `null`, so store the
+// bookmark object (or null) as JSON ourselves.
+const jsonSerializer = {
+  read: (value) => {
+    try {
+      return value ? JSON.parse(value) : null
+    } catch {
+      return null
+    }
+  },
+  write: (value) => JSON.stringify(value),
+}
+
+// A single, app-wide Quran bookmark. Setting a new one replaces any previous
+// bookmark, so only one ayah is ever bookmarked at a time. Shared at module
+// scope so every view/component reads and writes the same reactive value.
+const bookmark = useLocalStorage(STORAGE_KEYS.quranBookmark, null, { serializer: jsonSerializer })
+
+export const useQuranBookmark = () => {
+  const isBookmarked = (surahId, ayahNumber) =>
+    !!bookmark.value && bookmark.value.surahId === Number(surahId) && bookmark.value.ayahNumber === ayahNumber
+
+  const setBookmark = ({ surahId, surahName, ayahNumber, text }) => {
+    bookmark.value = { surahId: Number(surahId), surahName, ayahNumber, text }
+  }
+
+  const clearBookmark = () => {
+    bookmark.value = null
+  }
+
+  const toggleBookmark = (ayah) => {
+    if (isBookmarked(ayah.surahId, ayah.ayahNumber)) {
+      clearBookmark()
+    } else {
+      setBookmark(ayah)
+    }
+  }
+
+  return {
+    bookmark,
+    isBookmarked,
+    setBookmark,
+    clearBookmark,
+    toggleBookmark,
+  }
+}

--- a/src/features/quran/composables/useQuranBookmark.spec.js
+++ b/src/features/quran/composables/useQuranBookmark.spec.js
@@ -1,0 +1,51 @@
+import { beforeEach, describe, it, expect } from 'vitest'
+import { useQuranBookmark } from './useQuranBookmark'
+
+describe('useQuranBookmark', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    useQuranBookmark().clearBookmark()
+  })
+
+  it('starts with no bookmark', () => {
+    const { bookmark } = useQuranBookmark()
+    expect(bookmark.value).toBeNull()
+  })
+
+  it('sets a bookmark and reports it as bookmarked', () => {
+    const { setBookmark, isBookmarked, bookmark } = useQuranBookmark()
+    setBookmark({ surahId: 2, surahName: 'البقرة', ayahNumber: 5, text: 'آية' })
+
+    expect(bookmark.value).toEqual({ surahId: 2, surahName: 'البقرة', ayahNumber: 5, text: 'آية' })
+    expect(isBookmarked(2, 5)).toBe(true)
+    expect(isBookmarked('2', 5)).toBe(true)
+    expect(isBookmarked(2, 6)).toBe(false)
+  })
+
+  it('replaces any previous bookmark when a new one is set', () => {
+    const { setBookmark, isBookmarked } = useQuranBookmark()
+    setBookmark({ surahId: 2, surahName: 'البقرة', ayahNumber: 5, text: 'أولى' })
+    setBookmark({ surahId: 18, surahName: 'الكهف', ayahNumber: 10, text: 'ثانية' })
+
+    expect(isBookmarked(2, 5)).toBe(false)
+    expect(isBookmarked(18, 10)).toBe(true)
+  })
+
+  it('toggles a bookmark on and off for the same ayah', () => {
+    const { toggleBookmark, isBookmarked } = useQuranBookmark()
+    const ayah = { surahId: 36, surahName: 'يس', ayahNumber: 1, text: 'يس' }
+
+    toggleBookmark(ayah)
+    expect(isBookmarked(36, 1)).toBe(true)
+
+    toggleBookmark(ayah)
+    expect(isBookmarked(36, 1)).toBe(false)
+  })
+
+  it('clears the bookmark', () => {
+    const { setBookmark, clearBookmark, bookmark } = useQuranBookmark()
+    setBookmark({ surahId: 1, surahName: 'الفاتحة', ayahNumber: 2, text: 'الحمد لله' })
+    clearBookmark()
+    expect(bookmark.value).toBeNull()
+  })
+})

--- a/src/features/quran/views/QuranSurahView.vue
+++ b/src/features/quran/views/QuranSurahView.vue
@@ -1,7 +1,9 @@
 <script setup>
-import { computed, ref } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import { useOnline } from '@vueuse/core'
+import { useRoute } from 'vue-router'
 import { useRouteParams } from '@vueuse/router'
+import { toast } from 'vue-sonner'
 
 import Page from '@/layout/Page.vue'
 import Heading from '@/shared/ui/Heading.vue'
@@ -11,14 +13,17 @@ import AudioPlayer from '@/features/quran/components/QuranPlayer.vue'
 import AyahActionSheet from '@/features/quran/components/AyahActionSheet.vue'
 import TafseerSheet from '@/features/quran/components/TafseerSheet.vue'
 import { useQuranStore } from '@/features/quran/store'
+import { useQuranBookmark } from '@/features/quran/composables/useQuranBookmark'
 import { useAsyncData } from '@/shared/composables/useAsyncData'
 import { usePageMeta } from '@/shared/composables/usePageMeta'
 import { toArabicNumerals, removeBismillah } from '@/shared/utils/arabic'
 import { fetchSurah } from '@/features/quran/api'
 
 const online = useOnline()
+const route = useRoute()
 const surahId = useRouteParams('surah')
 const quranStore = useQuranStore()
+const { isBookmarked, toggleBookmark } = useQuranBookmark()
 const playerRef = ref(null)
 
 const {
@@ -77,6 +82,38 @@ const isCurrentVerse = (verse) => {
   if (!currentAyah || !surah.value) return false
   return currentAyah.ayah === verse.numberInSurah
 }
+
+const isBookmarkedVerse = (verse) => isBookmarked(surahId.value, verse.numberInSurah)
+
+const handleBookmark = () => {
+  const ayah = activeAyah.value
+  if (!ayah || !surah.value) return
+
+  const wasBookmarked = isBookmarkedVerse(ayah)
+  toggleBookmark({
+    surahId: surah.value.data.number,
+    surahName: surah.value.data.name,
+    ayahNumber: ayah.numberInSurah,
+    text: ayah.text,
+  })
+  toast.success(wasBookmarked ? 'تمت إزالة الإشارة المرجعية' : 'تم حفظ الإشارة المرجعية')
+}
+
+const scrollToAyah = (ayahNumber) => {
+  const el = document.getElementById(`ayah-${ayahNumber}`)
+  el?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+}
+
+// When arriving with ?ayah=N (e.g. from the bookmark card), bring that ayah
+// into view once the surah has rendered.
+watch(
+  [surah, () => route.query.ayah],
+  ([loadedSurah, ayahQuery]) => {
+    if (!loadedSurah || !ayahQuery) return
+    nextTick(() => scrollToAyah(Number(ayahQuery)))
+  },
+  { immediate: true },
+)
 </script>
 
 <template>
@@ -96,8 +133,9 @@ const isCurrentVerse = (verse) => {
 
         <template v-for="(ayah, index) in ayat" :key="ayah.number">
           <span
+            :id="`ayah-${ayah.numberInSurah}`"
             class="ayah clickable-ayah"
-            :class="{ 'current-ayah': isCurrentVerse(ayah) }"
+            :class="{ 'current-ayah': isCurrentVerse(ayah), 'bookmarked-ayah': isBookmarkedVerse(ayah) }"
             @click="activeAyah = ayah"
             :title="`خيارات الآية ${toArabicNumerals(ayah.numberInSurah)}`"
             >{{ ayah.text }}</span
@@ -117,8 +155,10 @@ const isCurrentVerse = (verse) => {
         :ayah="activeAyah"
         :surah-name="surah.data.name"
         :online="online"
+        :bookmarked="!!activeAyah && isBookmarkedVerse(activeAyah)"
         @recite="reciteAyah"
         @tafseer="tafseerAyah = activeAyah"
+        @bookmark="handleBookmark"
         @close="activeAyah = null"
       />
 
@@ -192,6 +232,13 @@ const isCurrentVerse = (verse) => {
 
     .current-ayah {
       background-color: var(--bs-secondary-bg);
+    }
+
+    .bookmarked-ayah {
+      background-color: rgba(var(--bs-primary-rgb), 0.12);
+      box-shadow: 0 0 0 1px rgba(var(--bs-primary-rgb), 0.35);
+      border-radius: 6px;
+      padding: 0 0.25rem;
     }
   }
 }

--- a/src/features/quran/views/QuranView.vue
+++ b/src/features/quran/views/QuranView.vue
@@ -1,10 +1,14 @@
 <script setup>
+import { IconBookmark, IconChevronLeft } from '@tabler/icons-vue'
 import Page from '@/layout/Page.vue'
 import Heading from '@/shared/ui/Heading.vue'
 import SearchableFavoritesList from '@/shared/ui/SearchableFavoritesList.vue'
 import surahs from '@/features/quran/data/surahs.js'
+import { useQuranBookmark } from '@/features/quran/composables/useQuranBookmark'
 import { toArabicNumerals } from '@/shared/utils/arabic'
 import { STORAGE_KEYS } from '@/shared/constants/storageKeys'
+
+const { bookmark } = useQuranBookmark()
 </script>
 
 <template>
@@ -14,6 +18,20 @@ import { STORAGE_KEYS } from '@/shared/constants/storageKeys'
       subtitle="إن له لحلاوة، وإن عليه لطلاوة، وإن أعلاه لمثمر، وإن أسفله لمغدق، وإنه يعلو ولا يعلى عليه."
       :share="true"
     />
+
+    <RouterLink
+      v-if="bookmark"
+      :to="{ name: 'quran-surah', params: { surah: bookmark.surahId }, query: { ayah: bookmark.ayahNumber } }"
+      class="bookmark-card"
+    >
+      <IconBookmark class="bookmark-card__icon" size="22" />
+      <span class="bookmark-card__body">
+        <span class="bookmark-card__label">متابعة القراءة</span>
+        <span class="bookmark-card__title">{{ bookmark.surahName }} - آية {{ toArabicNumerals(bookmark.ayahNumber) }}</span>
+        <span v-if="bookmark.text" class="bookmark-card__text font-quran">{{ bookmark.text }}</span>
+      </span>
+      <IconChevronLeft class="bookmark-card__chevron" size="20" />
+    </RouterLink>
 
     <SearchableFavoritesList
       :items="surahs"
@@ -46,3 +64,61 @@ import { STORAGE_KEYS } from '@/shared/constants/storageKeys'
     </SearchableFavoritesList>
   </Page>
 </template>
+
+<style lang="scss" scoped>
+.bookmark-card {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  margin-bottom: 1rem;
+  padding: 1rem;
+  border: 1px solid var(--bs-border-color);
+  border-radius: 8px;
+  background-color: rgba(var(--bs-primary-rgb), 0.06);
+  color: var(--bs-body-color);
+  text-decoration: none;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease;
+
+  &:hover {
+    background-color: rgba(var(--bs-primary-rgb), 0.12);
+    border-color: rgba(var(--bs-primary-rgb), 0.5);
+  }
+
+  &__icon {
+    flex-shrink: 0;
+    color: var(--bs-primary);
+  }
+
+  &__body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    min-width: 0;
+    flex: 1;
+  }
+
+  &__label {
+    font-size: 0.8rem;
+    color: var(--bs-secondary-color);
+  }
+
+  &__title {
+    font-weight: 600;
+  }
+
+  &__text {
+    font-size: 1.1rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__chevron {
+    flex-shrink: 0;
+    color: var(--bs-secondary-color);
+  }
+}
+</style>

--- a/src/features/quran/views/QuranView.vue
+++ b/src/features/quran/views/QuranView.vue
@@ -27,7 +27,9 @@ const { bookmark } = useQuranBookmark()
       <IconBookmark class="bookmark-card__icon" size="22" />
       <span class="bookmark-card__body">
         <span class="bookmark-card__label">متابعة القراءة</span>
-        <span class="bookmark-card__title">{{ bookmark.surahName }} - آية {{ toArabicNumerals(bookmark.ayahNumber) }}</span>
+        <span class="bookmark-card__title"
+          >{{ bookmark.surahName }} - آية {{ toArabicNumerals(bookmark.ayahNumber) }}</span
+        >
         <span v-if="bookmark.text" class="bookmark-card__text font-quran">{{ bookmark.text }}</span>
       </span>
       <IconChevronLeft class="bookmark-card__chevron" size="20" />

--- a/src/shared/constants/storageKeys.js
+++ b/src/shared/constants/storageKeys.js
@@ -21,5 +21,6 @@ export const STORAGE_KEYS = {
   azkarProgress: 'azkar-progress',
   azkarFavorites: 'azkarFavorites',
   quranFavorites: 'quranFavorites',
+  quranBookmark: 'quranBookmark',
   radioFavorites: 'radioFavorites',
 }


### PR DESCRIPTION
Store a single Quran bookmark in localStorage via a shared composable.
Setting a bookmark from the ayah bottom sheet replaces any previous one,
and the sheet toggles between set/unset based on the current state.

The bookmarked ayah gets a highlighted background, and the Quran index
shows a full-width "continue reading" card under the header that links
straight to the bookmarked ayah and scrolls it into view.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LCPey86BhdCDxj93go8fHH