### PR TITLE
Add playback speed, tafseer navigation, and tafseer edition setting

### DIFF
--- a/src/features/quran/components/QuranPlayer.vue
+++ b/src/features/quran/components/QuranPlayer.vue
@@ -1,8 +1,8 @@
 <script setup>
 import { ref, computed, watch, onMounted, onUnmounted, provide } from 'vue'
-import { useQuranStore } from '@/features/quran/store'
+import { useQuranStore, PLAYBACK_RATES } from '@/features/quran/store'
 import { useRadioStore } from '@/features/radio/store'
-import { IconPlayerPlay, IconPlayerPause, IconMicrophone2 } from '@tabler/icons-vue'
+import { IconPlayerPlay, IconPlayerPause, IconMicrophone2, IconGauge } from '@tabler/icons-vue'
 import { toArabicNumerals, formatTime } from '@/shared/utils/arabic'
 import BottomSheet from '@/shared/ui/BottomSheet.vue'
 import SettingsReciter from '@/features/settings/components/SettingsReciter.vue'
@@ -38,6 +38,27 @@ function closeReciterSheet() {
 }
 
 const progress = computed(() => (duration.value ? (currentTime.value / duration.value) * 100 : 0))
+
+const rateLabel = computed(() => `${toArabicNumerals(quranStore.playbackRate).replace('.', '٫')}×`)
+
+// Advance to the next speed preset, wrapping back to the slowest at the end.
+function cycleRate() {
+  const i = PLAYBACK_RATES.indexOf(Number(quranStore.playbackRate))
+  quranStore.setPlaybackRate(PLAYBACK_RATES[(i + 1) % PLAYBACK_RATES.length])
+}
+
+// The <audio> element resets playbackRate on every load, so reapply it whenever
+// the rate changes or a new source is loaded.
+function applyRate() {
+  if (audio.value) audio.value.playbackRate = Number(quranStore.playbackRate)
+}
+
+function onCanPlay() {
+  loading.value = false
+  applyRate()
+}
+
+watch(() => quranStore.playbackRate, applyRate)
 
 const currentAyahDisplay = computed(() => {
   const ayah = quranStore.currentAyah
@@ -102,6 +123,7 @@ function loadSource(url) {
   if (!audio.value || !url) return
   audio.value.src = url
   audio.value.load()
+  applyRate()
   isPlaying.value = false
   currentTime.value = 0
 }
@@ -138,8 +160,17 @@ defineExpose({ seekToAyah })
       </div>
 
       <button
+        @click="cycleRate"
+        class="btn btn-sm d-flex align-items-center gap-1 flex-shrink-0 player-chip"
+        :title="`سرعة التلاوة: ${rateLabel}`"
+      >
+        <IconGauge size="18" />
+        <span class="small">{{ rateLabel }}</span>
+      </button>
+
+      <button
         @click="openReciterSheet"
-        class="btn btn-sm d-flex align-items-center gap-1 flex-shrink-0 reciter-button"
+        class="btn btn-sm d-flex align-items-center gap-1 flex-shrink-0 player-chip"
         :title="`القارئ: ${quranStore.reciter?.name}`"
       >
         <IconMicrophone2 size="18" />
@@ -166,7 +197,7 @@ defineExpose({ seekToAyah })
     <audio
       ref="audio"
       @loadstart="loading = true"
-      @canplay="loading = false"
+      @canplay="onCanPlay"
       @timeupdate="onTimeUpdate"
       @ended="stop"
       @loadedmetadata="duration = $event.target.duration"
@@ -176,7 +207,7 @@ defineExpose({ seekToAyah })
 </template>
 
 <style lang="scss" scoped>
-.reciter-button {
+.player-chip {
   color: var(--bs-secondary-color);
   background-color: var(--bs-secondary-bg);
 

--- a/src/features/quran/components/QuranPlayer.vue
+++ b/src/features/quran/components/QuranPlayer.vue
@@ -160,15 +160,6 @@ defineExpose({ seekToAyah })
       </div>
 
       <button
-        @click="cycleRate"
-        class="btn btn-sm d-flex align-items-center gap-1 flex-shrink-0 player-chip"
-        :title="`سرعة التلاوة: ${rateLabel}`"
-      >
-        <IconGauge size="18" />
-        <span class="small">{{ rateLabel }}</span>
-      </button>
-
-      <button
         @click="openReciterSheet"
         class="btn btn-sm d-flex align-items-center gap-1 flex-shrink-0 player-chip"
         :title="`القارئ: ${quranStore.reciter?.name}`"
@@ -188,8 +179,18 @@ defineExpose({ seekToAyah })
       <div class="progress" style="height: 0.25rem">
         <div class="progress-bar" :style="{ width: progress + '%' }"></div>
       </div>
-      <div class="d-flex justify-content-between small text-muted mt-1">
+      <div class="d-flex justify-content-between align-items-center small text-muted mt-1">
         <span>{{ formatTime(currentTime) }}</span>
+
+        <button
+          @click="cycleRate"
+          class="speed-toggle d-flex align-items-center gap-1"
+          :title="`سرعة التلاوة: ${rateLabel}`"
+        >
+          <IconGauge size="15" />
+          <span>{{ rateLabel }}</span>
+        </button>
+
         <span>{{ formatTime(duration) }}</span>
       </div>
     </div>
@@ -218,6 +219,21 @@ defineExpose({ seekToAyah })
 
   .text-truncate {
     max-width: 7.5rem;
+  }
+}
+
+// Sits on the muted time row, so it stays understated until hovered.
+.speed-toggle {
+  padding: 0 0.4rem;
+  border: 0;
+  border-radius: 0.5rem;
+  background: none;
+  color: inherit;
+  font-variant-numeric: tabular-nums;
+
+  &:hover {
+    color: var(--bs-body-color);
+    background-color: var(--bs-secondary-bg);
   }
 }
 </style>

--- a/src/features/quran/components/QuranPlayer.vue
+++ b/src/features/quran/components/QuranPlayer.vue
@@ -44,18 +44,13 @@ const rateLabel = computed(() => `${toArabicNumerals(quranStore.playbackRate).re
 // Advance to the next speed preset, wrapping back to the slowest at the end.
 function cycleRate() {
   const i = PLAYBACK_RATES.indexOf(Number(quranStore.playbackRate))
-  quranStore.setPlaybackRate(PLAYBACK_RATES[(i + 1) % PLAYBACK_RATES.length])
+  quranStore.playbackRate = PLAYBACK_RATES[(i + 1) % PLAYBACK_RATES.length]
 }
 
-// The <audio> element resets playbackRate on every load, so reapply it whenever
-// the rate changes or a new source is loaded.
+// The <audio> element resets playbackRate when a new source loads, so it's
+// reapplied on every play; this watch only covers changes made mid-playback.
 function applyRate() {
   if (audio.value) audio.value.playbackRate = Number(quranStore.playbackRate)
-}
-
-function onCanPlay() {
-  loading.value = false
-  applyRate()
 }
 
 watch(() => quranStore.playbackRate, applyRate)
@@ -69,6 +64,7 @@ const currentAyahDisplay = computed(() => {
 async function tryPlay() {
   if (!audio.value) return
   if (radioStore.isPlaying) radioStore.stop()
+  applyRate()
   try {
     await audio.value.play()
     isPlaying.value = true
@@ -123,7 +119,6 @@ function loadSource(url) {
   if (!audio.value || !url) return
   audio.value.src = url
   audio.value.load()
-  applyRate()
   isPlaying.value = false
   currentTime.value = 0
 }
@@ -201,7 +196,7 @@ defineExpose({ seekToAyah })
     <audio
       ref="audio"
       @loadstart="loading = true"
-      @canplay="onCanPlay"
+      @canplay="loading = false"
       @timeupdate="onTimeUpdate"
       @ended="stop"
       @loadedmetadata="duration = $event.target.duration"

--- a/src/features/quran/components/QuranPlayer.vue
+++ b/src/features/quran/components/QuranPlayer.vue
@@ -47,14 +47,6 @@ function cycleRate() {
   quranStore.playbackRate = PLAYBACK_RATES[(i + 1) % PLAYBACK_RATES.length]
 }
 
-// The <audio> element resets playbackRate when a new source loads, so it's
-// reapplied on every play; this watch only covers changes made mid-playback.
-function applyRate() {
-  if (audio.value) audio.value.playbackRate = Number(quranStore.playbackRate)
-}
-
-watch(() => quranStore.playbackRate, applyRate)
-
 const currentAyahDisplay = computed(() => {
   const ayah = quranStore.currentAyah
   if (!ayah || !quranStore.surahName) return null
@@ -64,7 +56,8 @@ const currentAyahDisplay = computed(() => {
 async function tryPlay() {
   if (!audio.value) return
   if (radioStore.isPlaying) radioStore.stop()
-  applyRate()
+  // The browser resets playbackRate on every source load, so set it before play.
+  audio.value.playbackRate = Number(quranStore.playbackRate)
   try {
     await audio.value.play()
     isPlaying.value = true
@@ -182,7 +175,7 @@ defineExpose({ seekToAyah })
 
           <button
             type="button"
-            class="speed-toggle d-flex align-items-center gap-1"
+            class="btn btn-sm btn-link link-secondary text-decoration-none d-flex align-items-center gap-1 py-0 px-1"
             @click="cycleRate"
             :title="`سرعة التلاوة: ${rateLabel}`"
           >
@@ -195,6 +188,7 @@ defineExpose({ seekToAyah })
 
     <audio
       ref="audio"
+      .playbackRate="Number(quranStore.playbackRate)"
       @loadstart="loading = true"
       @canplay="loading = false"
       @timeupdate="onTimeUpdate"
@@ -217,21 +211,6 @@ defineExpose({ seekToAyah })
 
   .text-truncate {
     max-width: 7.5rem;
-  }
-}
-
-// Sits on the muted time row, so it stays understated until hovered.
-.speed-toggle {
-  padding: 0.1rem 0.4rem;
-  border: 0;
-  border-radius: 0.5rem;
-  background: none;
-  color: inherit;
-  font-variant-numeric: tabular-nums;
-
-  &:hover {
-    color: var(--bs-body-color);
-    background-color: var(--bs-secondary-bg);
   }
 }
 </style>

--- a/src/features/quran/components/QuranPlayer.vue
+++ b/src/features/quran/components/QuranPlayer.vue
@@ -39,13 +39,8 @@ function closeReciterSheet() {
 
 const progress = computed(() => (duration.value ? (currentTime.value / duration.value) * 100 : 0))
 
-const rateLabel = computed(() => `${toArabicNumerals(quranStore.playbackRate).replace('.', '٫')}×`)
-
-// Advance to the next speed preset, wrapping back to the slowest at the end.
-function cycleRate() {
-  const i = PLAYBACK_RATES.indexOf(Number(quranStore.playbackRate))
-  quranStore.setPlaybackRate(PLAYBACK_RATES[(i + 1) % PLAYBACK_RATES.length])
-}
+const formatRate = (rate) => `${toArabicNumerals(rate).replace('.', '٫')}×`
+const rateLabel = computed(() => formatRate(quranStore.playbackRate))
 
 // The <audio> element resets playbackRate on every load, so reapply it whenever
 // the rate changes or a new source is loaded.
@@ -182,16 +177,36 @@ defineExpose({ seekToAyah })
       <div class="d-flex justify-content-between align-items-center small text-muted mt-1">
         <span>{{ formatTime(currentTime) }}</span>
 
-        <button
-          @click="cycleRate"
-          class="speed-toggle d-flex align-items-center gap-1"
-          :title="`سرعة التلاوة: ${rateLabel}`"
-        >
-          <IconGauge size="15" />
-          <span>{{ rateLabel }}</span>
-        </button>
+        <div class="d-flex align-items-center gap-2">
+          <span>{{ formatTime(duration) }}</span>
 
-        <span>{{ formatTime(duration) }}</span>
+          <div class="dropup">
+            <button
+              type="button"
+              class="speed-toggle d-flex align-items-center gap-1"
+              data-bs-toggle="dropdown"
+              data-bs-display="static"
+              aria-expanded="false"
+              :title="`سرعة التلاوة: ${rateLabel}`"
+            >
+              <IconGauge size="15" />
+              <span>{{ rateLabel }}</span>
+            </button>
+
+            <ul class="dropdown-menu dropdown-menu-end speed-menu">
+              <li v-for="rate in PLAYBACK_RATES" :key="rate">
+                <button
+                  type="button"
+                  class="dropdown-item text-center"
+                  :class="{ active: Number(quranStore.playbackRate) === rate }"
+                  @click="quranStore.setPlaybackRate(rate)"
+                >
+                  {{ formatRate(rate) }}
+                </button>
+              </li>
+            </ul>
+          </div>
+        </div>
       </div>
     </div>
 
@@ -222,18 +237,27 @@ defineExpose({ seekToAyah })
   }
 }
 
-// Sits on the muted time row, so it stays understated until hovered.
+// Sits on the muted time row, so it stays understated until hovered/open.
 .speed-toggle {
-  padding: 0 0.4rem;
+  padding: 0.1rem 0.4rem;
   border: 0;
   border-radius: 0.5rem;
   background: none;
   color: inherit;
   font-variant-numeric: tabular-nums;
 
-  &:hover {
+  &:hover,
+  &[aria-expanded='true'] {
     color: var(--bs-body-color);
     background-color: var(--bs-secondary-bg);
+  }
+}
+
+.speed-menu {
+  min-width: 5rem;
+
+  .dropdown-item {
+    font-variant-numeric: tabular-nums;
   }
 }
 </style>

--- a/src/features/quran/components/QuranPlayer.vue
+++ b/src/features/quran/components/QuranPlayer.vue
@@ -175,7 +175,7 @@ defineExpose({ seekToAyah })
 
           <button
             type="button"
-            class="btn btn-sm btn-link link-secondary text-decoration-none d-flex align-items-center gap-1 py-0 px-1"
+            class="btn btn-flat btn-sm d-flex align-items-center gap-1"
             @click="cycleRate"
             :title="`سرعة التلاوة: ${rateLabel}`"
           >

--- a/src/features/quran/components/QuranPlayer.vue
+++ b/src/features/quran/components/QuranPlayer.vue
@@ -39,8 +39,13 @@ function closeReciterSheet() {
 
 const progress = computed(() => (duration.value ? (currentTime.value / duration.value) * 100 : 0))
 
-const formatRate = (rate) => `${toArabicNumerals(rate).replace('.', '٫')}×`
-const rateLabel = computed(() => formatRate(quranStore.playbackRate))
+const rateLabel = computed(() => `${toArabicNumerals(quranStore.playbackRate).replace('.', '٫')}×`)
+
+// Advance to the next speed preset, wrapping back to the slowest at the end.
+function cycleRate() {
+  const i = PLAYBACK_RATES.indexOf(Number(quranStore.playbackRate))
+  quranStore.setPlaybackRate(PLAYBACK_RATES[(i + 1) % PLAYBACK_RATES.length])
+}
 
 // The <audio> element resets playbackRate on every load, so reapply it whenever
 // the rate changes or a new source is loaded.
@@ -180,32 +185,15 @@ defineExpose({ seekToAyah })
         <div class="d-flex align-items-center gap-2">
           <span>{{ formatTime(duration) }}</span>
 
-          <div class="dropup">
-            <button
-              type="button"
-              class="speed-toggle d-flex align-items-center gap-1"
-              data-bs-toggle="dropdown"
-              data-bs-display="static"
-              aria-expanded="false"
-              :title="`سرعة التلاوة: ${rateLabel}`"
-            >
-              <IconGauge size="15" />
-              <span>{{ rateLabel }}</span>
-            </button>
-
-            <ul class="dropdown-menu dropdown-menu-end speed-menu">
-              <li v-for="rate in PLAYBACK_RATES" :key="rate">
-                <button
-                  type="button"
-                  class="dropdown-item text-center"
-                  :class="{ active: Number(quranStore.playbackRate) === rate }"
-                  @click="quranStore.setPlaybackRate(rate)"
-                >
-                  {{ formatRate(rate) }}
-                </button>
-              </li>
-            </ul>
-          </div>
+          <button
+            type="button"
+            class="speed-toggle d-flex align-items-center gap-1"
+            @click="cycleRate"
+            :title="`سرعة التلاوة: ${rateLabel}`"
+          >
+            <IconGauge size="15" />
+            <span>{{ rateLabel }}</span>
+          </button>
         </div>
       </div>
     </div>
@@ -237,7 +225,7 @@ defineExpose({ seekToAyah })
   }
 }
 
-// Sits on the muted time row, so it stays understated until hovered/open.
+// Sits on the muted time row, so it stays understated until hovered.
 .speed-toggle {
   padding: 0.1rem 0.4rem;
   border: 0;
@@ -246,18 +234,9 @@ defineExpose({ seekToAyah })
   color: inherit;
   font-variant-numeric: tabular-nums;
 
-  &:hover,
-  &[aria-expanded='true'] {
+  &:hover {
     color: var(--bs-body-color);
     background-color: var(--bs-secondary-bg);
-  }
-}
-
-.speed-menu {
-  min-width: 5rem;
-
-  .dropdown-item {
-    font-variant-numeric: tabular-nums;
   }
 }
 </style>

--- a/src/features/quran/components/RandomAyah.vue
+++ b/src/features/quran/components/RandomAyah.vue
@@ -6,6 +6,7 @@ import { toArabicNumerals, removeBismillah } from '@/shared/utils/arabic'
 import { API } from '@/shared/constants/api'
 import { IconRefresh, IconChevronRight, IconChevronLeft, IconPlayerPlay, IconPlayerPause } from '@tabler/icons-vue'
 import { useReconnectExecute } from '@/shared/composables/useReconnectExecute'
+import { useQuranStore } from '@/features/quran/store'
 
 import LoadingState from '@/shared/ui/LoadingState.vue'
 import ErrorState from '@/shared/ui/ErrorState.vue'
@@ -14,10 +15,12 @@ import OfflineState from '@/shared/ui/OfflineState.vue'
 // Check if the user is online
 const online = useOnline()
 
+const quranStore = useQuranStore()
+
 const TOTAL_AYAHS = 6236
 const current = ref(Math.floor(Math.random() * TOTAL_AYAHS) + 1)
-const editions = ['quran-uthmani', 'ar.muyassar', 'ar.alafasy']
-const endpoint = computed(() => `${API.quranCloud}/ayah/${current.value}/editions/${editions.join(',')}`)
+const editions = computed(() => ['quran-uthmani', quranStore.currentTafseer, 'ar.alafasy'])
+const endpoint = computed(() => `${API.quranCloud}/ayah/${current.value}/editions/${editions.value.join(',')}`)
 
 const { isFetching, data, error, execute } = useFetch(endpoint, { refetch: true }).json().get()
 const ayah = computed(() => data.value?.data?.[0])

--- a/src/features/quran/components/TafseerSheet.vue
+++ b/src/features/quran/components/TafseerSheet.vue
@@ -14,7 +14,6 @@ import OfflineState from '@/shared/ui/OfflineState.vue'
 
 const props = defineProps({
   ayah: { type: Object, default: null },
-  surahName: { type: String, default: '' },
   hasPrev: { type: Boolean, default: false },
   hasNext: { type: Boolean, default: false },
 })

--- a/src/features/quran/components/TafseerSheet.vue
+++ b/src/features/quran/components/TafseerSheet.vue
@@ -3,6 +3,9 @@ import { computed, ref, watch } from 'vue'
 import { useFetch, useOnline } from '@vueuse/core'
 import { toArabicNumerals } from '@/shared/utils/arabic'
 import { API } from '@/shared/constants/api'
+import { useQuranStore } from '@/features/quran/store'
+import tafseers from '@/features/quran/data/tafseers.js'
+import { IconChevronRight, IconChevronLeft } from '@tabler/icons-vue'
 
 import BottomSheet from '@/shared/ui/BottomSheet.vue'
 import LoadingState from '@/shared/ui/LoadingState.vue'
@@ -12,34 +15,54 @@ import OfflineState from '@/shared/ui/OfflineState.vue'
 const props = defineProps({
   ayah: { type: Object, default: null },
   surahName: { type: String, default: '' },
+  hasPrev: { type: Boolean, default: false },
+  hasNext: { type: Boolean, default: false },
 })
 
-const emit = defineEmits(['close'])
+const emit = defineEmits(['close', 'prev', 'next'])
 
 const online = useOnline()
+const quranStore = useQuranStore()
 
 // Keep the last opened ayah so the content stays rendered while the sheet
 // animates closed (props.ayah becomes null the moment closing starts).
 const displayAyah = ref(props.ayah)
 
+// Seeds from the saved default, but lets the user switch edition just for this
+// sheet — picking here never writes back to the stored default.
+const edition = ref(quranStore.currentTafseer)
+
 const url = ref('')
 const { isFetching, data, error, execute } = useFetch(url, { immediate: false }).json().get()
 const tafsir = computed(() => data.value?.data?.[0])
 
-watch(
-  () => props.ayah,
-  (ayah) => {
-    if (!ayah) return
-    displayAyah.value = ayah
-    url.value = `${API.quranCloud}/ayah/${ayah.number}/editions/ar.muyassar`
-    if (online.value) execute()
-  },
-)
+watch([() => props.ayah, edition], ([ayah]) => {
+  if (!ayah) return
+  displayAyah.value = ayah
+  url.value = `${API.quranCloud}/ayah/${ayah.number}/editions/${edition.value}`
+  if (online.value) execute()
+})
 </script>
 
 <template>
   <BottomSheet :show="!!ayah" title="تفسير الآية" @close="emit('close')">
     <div class="p-4">
+      <template v-if="displayAyah">
+        <p class="fs-3 text-center lh-lg font-quran mb-4">
+          {{ displayAyah.text }}
+          <span class="ayah-number">{{ toArabicNumerals(displayAyah.numberInSurah) }}</span>
+        </p>
+
+        <div class="form-floating mb-4">
+          <select class="form-select" id="tafseerEdition" v-model="edition">
+            <option v-for="tafseer in tafseers" :key="tafseer.identifier" :value="tafseer.identifier">
+              {{ tafseer.name }}
+            </option>
+          </select>
+          <label for="tafseerEdition">التفسير</label>
+        </div>
+      </template>
+
       <LoadingState v-if="isFetching" message="جاري تحميل التفسير..." />
 
       <OfflineState v-else-if="!online && !tafsir" />
@@ -47,13 +70,19 @@ watch(
       <ErrorState v-else-if="error" :code="500" message="حدث خطأ أثناء تحميل التفسير، برجاء المحاولة مرة أخرى." />
 
       <template v-else-if="displayAyah && tafsir">
-        <p class="fs-3 text-center lh-lg font-quran mb-4">
-          {{ displayAyah.text }}
-          <span class="ayah-number">{{ toArabicNumerals(displayAyah.numberInSurah) }}</span>
-        </p>
-
-        <span class="d-block small fw-semibold text-secondary mb-2">{{ tafsir.edition.name }}</span>
         <p class="mb-0">{{ tafsir.text }}</p>
+
+        <div class="d-flex justify-content-between gap-2 mt-4 pt-3 border-top">
+          <button class="btn btn-flat d-flex align-items-center gap-1" :disabled="!hasPrev" @click="emit('prev')">
+            <IconChevronRight size="18" />
+            <span>الآية السابقة</span>
+          </button>
+
+          <button class="btn btn-flat d-flex align-items-center gap-1" :disabled="!hasNext" @click="emit('next')">
+            <span>الآية التالية</span>
+            <IconChevronLeft size="18" />
+          </button>
+        </div>
       </template>
     </div>
   </BottomSheet>

--- a/src/features/quran/data/tafseers.js
+++ b/src/features/quran/data/tafseers.js
@@ -1,0 +1,10 @@
+// Arabic tafsir editions available on api.alquran.cloud (type=tafsir).
+// `identifier` is the edition slug used in the /ayah/{n}/editions/{id} endpoint.
+export default [
+  { identifier: 'ar.muyassar', name: 'التفسير الميسر' },
+  { identifier: 'ar.jalalayn', name: 'تفسير الجلالين' },
+  { identifier: 'ar.miqbas', name: 'تنوير المقباس من تفسير ابن عباس' },
+  { identifier: 'ar.baghawi', name: 'معالم التنزيل (تفسير البغوي)' },
+  { identifier: 'ar.qurtubi', name: 'تفسير القرطبي' },
+  { identifier: 'ar.waseet', name: 'الوسيط في تفسير القرآن الكريم' },
+]

--- a/src/features/quran/store.js
+++ b/src/features/quran/store.js
@@ -6,9 +6,15 @@ import { STORAGE_KEYS } from '@/shared/constants/storageKeys'
 import { API } from '@/shared/constants/api'
 
 const DEFAULT_RECITER_ID = 51
+const DEFAULT_TAFSEER = 'ar.muyassar'
+
+// Playback speed presets offered by the player, from slowest to fastest.
+export const PLAYBACK_RATES = [0.5, 0.75, 1, 1.25, 1.5, 1.75, 2]
 
 export const useQuranStore = defineStore('quran', () => {
   const currentReciter = useLocalStorage(STORAGE_KEYS.currentReciter, DEFAULT_RECITER_ID)
+  const currentTafseer = useLocalStorage(STORAGE_KEYS.currentTafseer, DEFAULT_TAFSEER)
+  const playbackRate = useLocalStorage(STORAGE_KEYS.playbackRate, 1)
 
   const surahAudioUrl = ref(null)
   const surahName = ref(null)
@@ -101,8 +107,14 @@ export const useQuranStore = defineStore('quran', () => {
     }
   }
 
+  function setPlaybackRate(rate) {
+    playbackRate.value = rate
+  }
+
   return {
     currentReciter,
+    currentTafseer,
+    playbackRate,
     surahAudioUrl,
     surahName,
 
@@ -115,5 +127,6 @@ export const useQuranStore = defineStore('quran', () => {
     getAyahStartTime,
     resetAyahTracking,
     changeReciter,
+    setPlaybackRate,
   }
 })

--- a/src/features/quran/store.js
+++ b/src/features/quran/store.js
@@ -107,10 +107,6 @@ export const useQuranStore = defineStore('quran', () => {
     }
   }
 
-  function setPlaybackRate(rate) {
-    playbackRate.value = rate
-  }
-
   return {
     currentReciter,
     currentTafseer,
@@ -127,6 +123,5 @@ export const useQuranStore = defineStore('quran', () => {
     getAyahStartTime,
     resetAyahTracking,
     changeReciter,
-    setPlaybackRate,
   }
 })

--- a/src/features/quran/views/QuranSurahView.vue
+++ b/src/features/quran/views/QuranSurahView.vue
@@ -78,12 +78,9 @@ const tafseerIndex = computed(() => ayat.value.findIndex((a) => a.number === taf
 const hasPrevTafseer = computed(() => tafseerIndex.value > 0)
 const hasNextTafseer = computed(() => tafseerIndex.value >= 0 && tafseerIndex.value < ayat.value.length - 1)
 
-const tafseerPrev = () => {
-  if (hasPrevTafseer.value) tafseerAyah.value = ayat.value[tafseerIndex.value - 1]
-}
-
-const tafseerNext = () => {
-  if (hasNextTafseer.value) tafseerAyah.value = ayat.value[tafseerIndex.value + 1]
+const stepTafseer = (delta) => {
+  const next = ayat.value[tafseerIndex.value + delta]
+  if (next) tafseerAyah.value = next
 }
 
 const reciteAyah = () => {
@@ -180,8 +177,8 @@ watch(
         :surah-name="surah.data.name"
         :has-prev="hasPrevTafseer"
         :has-next="hasNextTafseer"
-        @prev="tafseerPrev"
-        @next="tafseerNext"
+        @prev="stepTafseer(-1)"
+        @next="stepTafseer(1)"
         @close="tafseerAyah = null"
       />
     </Page>

--- a/src/features/quran/views/QuranSurahView.vue
+++ b/src/features/quran/views/QuranSurahView.vue
@@ -73,6 +73,19 @@ const ayat = computed(() => {
 const activeAyah = ref(null)
 const tafseerAyah = ref(null)
 
+// Navigate the tafseer sheet through the surah's ayat without leaving the sheet.
+const tafseerIndex = computed(() => ayat.value.findIndex((a) => a.number === tafseerAyah.value?.number))
+const hasPrevTafseer = computed(() => tafseerIndex.value > 0)
+const hasNextTafseer = computed(() => tafseerIndex.value >= 0 && tafseerIndex.value < ayat.value.length - 1)
+
+const tafseerPrev = () => {
+  if (hasPrevTafseer.value) tafseerAyah.value = ayat.value[tafseerIndex.value - 1]
+}
+
+const tafseerNext = () => {
+  if (hasNextTafseer.value) tafseerAyah.value = ayat.value[tafseerIndex.value + 1]
+}
+
 const reciteAyah = () => {
   playerRef.value?.seekToAyah(activeAyah.value?.numberInSurah)
 }
@@ -162,7 +175,15 @@ watch(
         @close="activeAyah = null"
       />
 
-      <TafseerSheet :ayah="tafseerAyah" :surah-name="surah.data.name" @close="tafseerAyah = null" />
+      <TafseerSheet
+        :ayah="tafseerAyah"
+        :surah-name="surah.data.name"
+        :has-prev="hasPrevTafseer"
+        :has-next="hasNextTafseer"
+        @prev="tafseerPrev"
+        @next="tafseerNext"
+        @close="tafseerAyah = null"
+      />
     </Page>
   </AsyncContent>
 </template>

--- a/src/features/quran/views/QuranSurahView.vue
+++ b/src/features/quran/views/QuranSurahView.vue
@@ -75,8 +75,6 @@ const tafseerAyah = ref(null)
 
 // Navigate the tafseer sheet through the surah's ayat without leaving the sheet.
 const tafseerIndex = computed(() => ayat.value.findIndex((a) => a.number === tafseerAyah.value?.number))
-const hasPrevTafseer = computed(() => tafseerIndex.value > 0)
-const hasNextTafseer = computed(() => tafseerIndex.value >= 0 && tafseerIndex.value < ayat.value.length - 1)
 
 const stepTafseer = (delta) => {
   const next = ayat.value[tafseerIndex.value + delta]
@@ -174,9 +172,8 @@ watch(
 
       <TafseerSheet
         :ayah="tafseerAyah"
-        :surah-name="surah.data.name"
-        :has-prev="hasPrevTafseer"
-        :has-next="hasNextTafseer"
+        :has-prev="tafseerIndex > 0"
+        :has-next="tafseerIndex >= 0 && tafseerIndex < ayat.length - 1"
         @prev="stepTafseer(-1)"
         @next="stepTafseer(1)"
         @close="tafseerAyah = null"

--- a/src/features/settings/components/SettingsTafseer.vue
+++ b/src/features/settings/components/SettingsTafseer.vue
@@ -1,0 +1,21 @@
+<script setup>
+import tafseers from '@/features/quran/data/tafseers.js'
+import { useQuranStore } from '@/features/quran/store.js'
+import { IconBook } from '@tabler/icons-vue'
+import SettingsSection from './SettingsSection.vue'
+
+const quranStore = useQuranStore()
+</script>
+
+<template>
+  <SettingsSection title="التفسير" description="اختر تفسير الآيات المفضل لديك" :icon="IconBook">
+    <div class="form-floating">
+      <select class="form-select" id="currentTafseer" v-model="quranStore.currentTafseer">
+        <option v-for="tafseer in tafseers" :key="tafseer.identifier" :value="tafseer.identifier">
+          {{ tafseer.name }}
+        </option>
+      </select>
+      <label for="currentTafseer">التفسير الافتراضي</label>
+    </div>
+  </SettingsSection>
+</template>

--- a/src/features/settings/views/SettingsView.vue
+++ b/src/features/settings/views/SettingsView.vue
@@ -17,6 +17,7 @@ import SettingsTheme from '../components/SettingsTheme.vue'
 import SettingsFontSize from '../components/SettingsFontSize.vue'
 import SettingsPrayerTimes from '../components/SettingsPrayerTimes.vue'
 import SettingsReciter from '../components/SettingsReciter.vue'
+import SettingsTafseer from '../components/SettingsTafseer.vue'
 import SettingsZekr from '../components/SettingsZekr.vue'
 import SettingsAppUpdates from '../components/SettingsAppUpdates.vue'
 import SettingsDownloadAssets from '../components/SettingsDownloadAssets.vue'
@@ -62,7 +63,10 @@ const activeTab = computed(() => route.params.tab || 'appearance')
 
         <SettingsPrayerTimes v-else-if="activeTab === 'prayer'" />
 
-        <SettingsReciter v-else-if="activeTab === 'quran'" />
+        <div v-else-if="activeTab === 'quran'" class="settings-stack">
+          <SettingsReciter />
+          <SettingsTafseer />
+        </div>
 
         <SettingsZekr v-else-if="activeTab === 'azkar'" />
 

--- a/src/shared/constants/storageKeys.js
+++ b/src/shared/constants/storageKeys.js
@@ -17,6 +17,8 @@ export const STORAGE_KEYS = {
   prayerTimesLayout: 'prayer-times-layout',
 
   currentReciter: 'currentReciter',
+  currentTafseer: 'currentTafseer',
+  playbackRate: 'quran-playback-rate',
 
   azkarProgress: 'azkar-progress',
   azkarFavorites: 'azkarFavorites',


### PR DESCRIPTION
- QuranPlayer: cycle recitation speed through 0.5x–2x presets, persisted
- TafseerSheet: next/previous ayah navigation and an edition dropdown to
  switch tafseer per-sheet without changing the default
- Add a default tafseer setting under Quran settings, used by the tafseer
  sheet and the home random-ayah widget

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01B6dJ7xbpEvoE6aX17ymBsY