### PR TITLE
Add prev/next surah navigation to surah view

### DIFF
--- a/src/features/quran/views/QuranSurahView.vue
+++ b/src/features/quran/views/QuranSurahView.vue
@@ -31,12 +31,20 @@ const {
   data: surah,
   error,
   pending: isFetching,
+  execute: reloadSurah,
 } = useAsyncData(async () => {
   const result = await fetchSurah(surahId.value)
   if (online.value && result) {
     await quranStore.loadSurahAudio(result.data.number, result.data.name)
   }
   return result
+})
+
+// Vue Router reuses this component when only the :surah param changes (e.g. the
+// prev/next buttons), so re-fetch and scroll back to the top on each switch.
+watch(surahId, () => {
+  reloadSurah()
+  window.scrollTo({ top: 0 })
 })
 
 const revelationLabel = computed(() => (surah.value?.data.revelationType === 'Meccan' ? 'مكية' : 'مدنية'))
@@ -157,27 +165,26 @@ watch(
         </template>
       </div>
 
-      <div class="d-flex justify-content-between gap-2 mb-2">
+      <div class="d-flex justify-content-center align-items-center gap-2">
         <RouterLink
           v-if="surahNumber > 1"
           :to="{ name: 'quran-surah', params: { surah: surahNumber - 1 } }"
           class="btn btn-flat d-inline-flex align-items-center gap-2"
         >
           <IconArrowRight size="1.25rem" />
-          <span>السورة السابقة</span>
+          <span>السابقة</span>
         </RouterLink>
+
+        <BackButton :to="{ name: 'quran' }" button-class="btn-primary" />
+
         <RouterLink
           v-if="surahNumber < 114"
           :to="{ name: 'quran-surah', params: { surah: surahNumber + 1 } }"
-          class="btn btn-flat d-inline-flex align-items-center gap-2 ms-auto"
+          class="btn btn-flat d-inline-flex align-items-center gap-2"
         >
-          <span>السورة التالية</span>
+          <span>التالية</span>
           <IconArrowLeft size="1.25rem" />
         </RouterLink>
-      </div>
-
-      <div class="d-flex justify-content-center">
-        <BackButton :to="{ name: 'quran' }" button-class="btn-primary" />
       </div>
 
       <AyahActionSheet


### PR DESCRIPTION
## What

Adds previous/next surah navigation at the bottom of the surah view, with the existing back button placed between them: `[السابقة] [العودة] [التالية]`.

## Changes

- New flat (`btn-flat`) prev/next buttons in `QuranSurahView.vue`, shown only when applicable (no "previous" on Al-Fatiha, no "next" on An-Nas).
- Re-fetch the surah when the `:surah` route param changes. Vue Router reuses the component on same-route param changes, so `useAsyncData` (which runs once) never refetched — the URL changed but content didn't. A `watch(surahId, …)` now reloads the surah and scrolls to the top on each switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K5qTABQWCiYTQeL6yj3Ao6)_