### PR TITLE
feat(prayers): add Aladhan calculation options to prayer time settings

### DIFF
--- a/src/features/prayers/components/PrayerTimes.vue
+++ b/src/features/prayers/components/PrayerTimes.vue
@@ -10,6 +10,7 @@ import ErrorState from '@/shared/ui/ErrorState.vue'
 import OfflineState from '@/shared/ui/OfflineState.vue'
 import { formatTime, toArabicNumerals } from '@/shared/utils/arabic'
 import { API } from '@/shared/constants/api'
+import { CALCULATION_FIELDS } from '@/features/prayers/constants/calculationOptions'
 
 import PrayerIcon from '@/features/prayers/components/icons/PrayerIcon.vue'
 
@@ -47,7 +48,21 @@ const longitude = computed(() => (hasPropsCoords.value ? props.long : store.long
 const endpoint = computed(() => {
   if (!latitude.value || !longitude.value) return null
   const today = new Date().toISOString().split('T')[0].split('-').reverse().join('-')
-  return `${API.aladhan}/timings/${today}?latitude=${latitude.value}&longitude=${longitude.value}&iso8601=true`
+
+  const params = new URLSearchParams({
+    latitude: latitude.value,
+    longitude: longitude.value,
+    iso8601: 'true',
+  })
+
+  // Append each calculation option only when the user picked a value other than
+  // "تلقائي" (AUTO), so the default behavior sends no calculation parameters.
+  for (const { key, param } of CALCULATION_FIELDS) {
+    const value = store[key]
+    if (value) params.append(param, value)
+  }
+
+  return `${API.aladhan}/timings/${today}?${params.toString()}`
 })
 
 // Fetch options

--- a/src/features/prayers/components/PrayerTimes.vue
+++ b/src/features/prayers/components/PrayerTimes.vue
@@ -55,8 +55,6 @@ const endpoint = computed(() => {
     iso8601: 'true',
   })
 
-  // Append each calculation option only when the user picked a value other than
-  // "تلقائي" (AUTO), so the default behavior sends no calculation parameters.
   for (const { key, param } of CALCULATION_FIELDS) {
     const value = store[key]
     if (value) params.append(param, value)

--- a/src/features/prayers/constants/calculationOptions.js
+++ b/src/features/prayers/constants/calculationOptions.js
@@ -37,11 +37,7 @@ export const CALCULATION_METHODS = [
 ]
 
 // `school` — juristic method for the Asr prayer.
-export const SCHOOLS = [
-  autoOption,
-  { value: '0', label: 'شافعي' },
-  { value: '1', label: 'حنفي' },
-]
+export const SCHOOLS = [autoOption, { value: '0', label: 'شافعي' }, { value: '1', label: 'حنفي' }]
 
 // `latitudeAdjustmentMethod` — adjusting times for higher latitudes.
 export const LATITUDE_ADJUSTMENT_METHODS = [

--- a/src/features/prayers/constants/calculationOptions.js
+++ b/src/features/prayers/constants/calculationOptions.js
@@ -1,0 +1,82 @@
+// Calculation options for the Aladhan `/timings` endpoint.
+// See: https://aladhan.com/prayer-times-api
+//
+// Every option list starts with an "تلقائي" (automatic) entry whose value is an
+// empty string. Selecting it omits the parameter from the request entirely,
+// which preserves the app's original behavior of letting the API pick defaults.
+export const AUTO = ''
+
+const autoOption = { value: AUTO, label: 'تلقائي' }
+
+// `method` — prayer time calculation authority.
+export const CALCULATION_METHODS = [
+  autoOption,
+  { value: '3', label: 'رابطة العالم الإسلامي' },
+  { value: '2', label: 'الجمعية الإسلامية لأمريكا الشمالية' },
+  { value: '5', label: 'الهيئة المصرية العامة للمساحة' },
+  { value: '4', label: 'جامعة أم القرى، مكة المكرمة' },
+  { value: '1', label: 'جامعة العلوم الإسلامية، كراتشي' },
+  { value: '7', label: 'معهد الجيوفيزياء، جامعة طهران' },
+  { value: '0', label: 'الشيعة الإثنا عشرية' },
+  { value: '8', label: 'منطقة الخليج' },
+  { value: '9', label: 'الكويت' },
+  { value: '10', label: 'قطر' },
+  { value: '11', label: 'مجلس العلماء الإسلامي، سنغافورة' },
+  { value: '12', label: 'الاتحاد الإسلامي في فرنسا' },
+  { value: '13', label: 'رئاسة الشؤون الدينية، تركيا' },
+  { value: '14', label: 'الإدارة الروحية لمسلمي روسيا' },
+  { value: '15', label: 'لجنة رؤية الهلال العالمية' },
+  { value: '16', label: 'دبي' },
+  { value: '17', label: 'دائرة التنمية الإسلامية الماليزية' },
+  { value: '18', label: 'تونس' },
+  { value: '19', label: 'الجزائر' },
+  { value: '20', label: 'وزارة الشؤون الدينية، إندونيسيا' },
+  { value: '21', label: 'المغرب' },
+  { value: '22', label: 'الجالية الإسلامية في لشبونة' },
+  { value: '23', label: 'وزارة الأوقاف والشؤون الإسلامية، الأردن' },
+]
+
+// `school` — juristic method for the Asr prayer.
+export const SCHOOLS = [
+  autoOption,
+  { value: '0', label: 'شافعي' },
+  { value: '1', label: 'حنفي' },
+]
+
+// `latitudeAdjustmentMethod` — adjusting times for higher latitudes.
+export const LATITUDE_ADJUSTMENT_METHODS = [
+  autoOption,
+  { value: '1', label: 'منتصف الليل' },
+  { value: '2', label: 'السُبع' },
+  { value: '3', label: 'حسب الزاوية' },
+]
+
+// `midnightMode` — how the midnight time is computed.
+export const MIDNIGHT_MODES = [
+  autoOption,
+  { value: '0', label: 'قياسي (من الغروب إلى الشروق)' },
+  { value: '1', label: 'جعفري (من الغروب إلى الفجر)' },
+]
+
+// `shafaq` — twilight used by the Moonsighting Committee method.
+export const SHAFAQ_OPTIONS = [
+  autoOption,
+  { value: 'general', label: 'عام' },
+  { value: 'ahmer', label: 'الأحمر' },
+  { value: 'abyad', label: 'الأبيض' },
+]
+
+// Field descriptors consumed by the settings UI and the store. `key` is the
+// store property, `param` is the Aladhan query parameter name.
+export const CALCULATION_FIELDS = [
+  { key: 'calcMethod', param: 'method', label: 'طريقة الحساب', options: CALCULATION_METHODS },
+  { key: 'calcSchool', param: 'school', label: 'المذهب (حساب العصر)', options: SCHOOLS },
+  {
+    key: 'calcLatitudeAdjustment',
+    param: 'latitudeAdjustmentMethod',
+    label: 'تعديل خطوط العرض العليا',
+    options: LATITUDE_ADJUSTMENT_METHODS,
+  },
+  { key: 'calcMidnightMode', param: 'midnightMode', label: 'وضع منتصف الليل', options: MIDNIGHT_MODES },
+  { key: 'calcShafaq', param: 'shafaq', label: 'الشفق', options: SHAFAQ_OPTIONS },
+]

--- a/src/features/prayers/constants/calculationOptions.js
+++ b/src/features/prayers/constants/calculationOptions.js
@@ -1,14 +1,7 @@
-// Calculation options for the Aladhan `/timings` endpoint.
-// See: https://aladhan.com/prayer-times-api
-//
-// Every option list starts with an "تلقائي" (automatic) entry whose value is an
-// empty string. Selecting it omits the parameter from the request entirely,
-// which preserves the app's original behavior of letting the API pick defaults.
 export const AUTO = ''
 
 const autoOption = { value: AUTO, label: 'تلقائي' }
 
-// `method` — prayer time calculation authority.
 export const CALCULATION_METHODS = [
   autoOption,
   { value: '3', label: 'رابطة العالم الإسلامي' },
@@ -36,10 +29,8 @@ export const CALCULATION_METHODS = [
   { value: '23', label: 'وزارة الأوقاف والشؤون الإسلامية، الأردن' },
 ]
 
-// `school` — juristic method for the Asr prayer.
 export const SCHOOLS = [autoOption, { value: '0', label: 'شافعي' }, { value: '1', label: 'حنفي' }]
 
-// `latitudeAdjustmentMethod` — adjusting times for higher latitudes.
 export const LATITUDE_ADJUSTMENT_METHODS = [
   autoOption,
   { value: '1', label: 'منتصف الليل' },
@@ -47,14 +38,12 @@ export const LATITUDE_ADJUSTMENT_METHODS = [
   { value: '3', label: 'حسب الزاوية' },
 ]
 
-// `midnightMode` — how the midnight time is computed.
 export const MIDNIGHT_MODES = [
   autoOption,
   { value: '0', label: 'قياسي (من الغروب إلى الشروق)' },
   { value: '1', label: 'جعفري (من الغروب إلى الفجر)' },
 ]
 
-// `shafaq` — twilight used by the Moonsighting Committee method.
 export const SHAFAQ_OPTIONS = [
   autoOption,
   { value: 'general', label: 'عام' },
@@ -62,8 +51,6 @@ export const SHAFAQ_OPTIONS = [
   { value: 'abyad', label: 'الأبيض' },
 ]
 
-// Field descriptors consumed by the settings UI and the store. `key` is the
-// store property, `param` is the Aladhan query parameter name.
 export const CALCULATION_FIELDS = [
   { key: 'calcMethod', param: 'method', label: 'طريقة الحساب', options: CALCULATION_METHODS },
   { key: 'calcSchool', param: 'school', label: 'المذهب (حساب العصر)', options: SCHOOLS },

--- a/src/features/prayers/store.js
+++ b/src/features/prayers/store.js
@@ -13,8 +13,6 @@ export const usePrayersStore = defineStore('prayers', function () {
   // Display layout: 'cards' | 'list' | 'auto'
   const layout = useLocalStorage(STORAGE_KEYS.prayerTimesLayout, 'auto')
 
-  // Aladhan calculation options. Each defaults to AUTO ('') which omits the
-  // corresponding query parameter, keeping the API's own defaults.
   const calcMethod = useLocalStorage(STORAGE_KEYS.prayerCalcMethod, AUTO)
   const calcSchool = useLocalStorage(STORAGE_KEYS.prayerCalcSchool, AUTO)
   const calcLatitudeAdjustment = useLocalStorage(STORAGE_KEYS.prayerCalcLatitudeAdjustment, AUTO)

--- a/src/features/prayers/store.js
+++ b/src/features/prayers/store.js
@@ -4,6 +4,7 @@ import { computed, ref } from 'vue'
 import { getCurrentPosition } from '@/shared/composables/useGeolocation'
 import { useIsMobile } from '@/shared/composables/useIsMobile'
 import { STORAGE_KEYS } from '@/shared/constants/storageKeys'
+import { AUTO } from '@/features/prayers/constants/calculationOptions'
 
 export const usePrayersStore = defineStore('prayers', function () {
   const longitude = useLocalStorage(STORAGE_KEYS.longitude, 0)
@@ -11,6 +12,14 @@ export const usePrayersStore = defineStore('prayers', function () {
 
   // Display layout: 'cards' | 'list' | 'auto'
   const layout = useLocalStorage(STORAGE_KEYS.prayerTimesLayout, 'auto')
+
+  // Aladhan calculation options. Each defaults to AUTO ('') which omits the
+  // corresponding query parameter, keeping the API's own defaults.
+  const calcMethod = useLocalStorage(STORAGE_KEYS.prayerCalcMethod, AUTO)
+  const calcSchool = useLocalStorage(STORAGE_KEYS.prayerCalcSchool, AUTO)
+  const calcLatitudeAdjustment = useLocalStorage(STORAGE_KEYS.prayerCalcLatitudeAdjustment, AUTO)
+  const calcMidnightMode = useLocalStorage(STORAGE_KEYS.prayerCalcMidnightMode, AUTO)
+  const calcShafaq = useLocalStorage(STORAGE_KEYS.prayerCalcShafaq, AUTO)
 
   const isCompactViewport = useIsMobile()
 
@@ -49,6 +58,11 @@ export const usePrayersStore = defineStore('prayers', function () {
     latitude,
     layout,
     vertical,
+    calcMethod,
+    calcSchool,
+    calcLatitudeAdjustment,
+    calcMidnightMode,
+    calcShafaq,
     isDetecting,
     detect,
     clear,

--- a/src/features/settings/components/SettingsPrayerTimes.vue
+++ b/src/features/settings/components/SettingsPrayerTimes.vue
@@ -11,8 +11,11 @@ import {
   IconClockHour4,
 } from '@tabler/icons-vue'
 import SettingsSection from './SettingsSection.vue'
+import { CALCULATION_FIELDS } from '@/features/prayers/constants/calculationOptions'
 
 const store = usePrayersStore()
+
+const calculationFields = CALCULATION_FIELDS
 const { detect } = usePrayerLocation()
 
 const location = computed(() => {
@@ -44,7 +47,7 @@ const location = computed(() => {
       </div>
     </div>
 
-    <div>
+    <div class="mb-3">
       <span class="d-block mb-2">طريقة العرض</span>
       <div class="btn-group-toggle">
         <button class="btn-toggle" :class="{ active: store.layout === 'cards' }" @click="store.layout = 'cards'">
@@ -59,6 +62,18 @@ const location = computed(() => {
           <IconDevices :size="16" />
           <span>تلقائي</span>
         </button>
+      </div>
+    </div>
+
+    <div v-for="field in calculationFields" :key="field.key" class="mb-3">
+      <span class="d-block mb-2">{{ field.label }}</span>
+      <div class="form-floating">
+        <select :id="field.key" class="form-select" v-model="store[field.key]">
+          <option v-for="option in field.options" :key="option.value" :value="option.value">
+            {{ option.label }}
+          </option>
+        </select>
+        <label :for="field.key">{{ field.label }}</label>
       </div>
     </div>
   </SettingsSection>

--- a/src/features/settings/components/SettingsPrayerTimes.vue
+++ b/src/features/settings/components/SettingsPrayerTimes.vue
@@ -30,7 +30,6 @@ const location = computed(() => {
 <template>
   <SettingsSection title="مواقيت الصلاة" description="حدّد موقعك وطريقة عرض المواقيت" :icon="IconClockHour4">
     <div class="mb-3">
-      <span class="d-block mb-2">الموقع</span>
       <div class="input-group">
         <div class="form-floating">
           <input id="location" type="text" class="form-control" :value="location" readonly />
@@ -66,7 +65,6 @@ const location = computed(() => {
     </div>
 
     <div v-for="field in calculationFields" :key="field.key" class="mb-3">
-      <span class="d-block mb-2">{{ field.label }}</span>
       <div class="form-floating">
         <select :id="field.key" class="form-select" v-model="store[field.key]">
           <option v-for="option in field.options" :key="option.value" :value="option.value">

--- a/src/features/settings/components/SettingsReciter.vue
+++ b/src/features/settings/components/SettingsReciter.vue
@@ -23,7 +23,6 @@ function onRewayaChange(value) {
 <template>
   <SettingsSection title="القرآن الكريم" description="اختر الرواية والقارئ المفضل لديك" :icon="IconMicrophone2">
     <div class="mb-3">
-      <span class="d-block mb-2">الرواية</span>
       <div class="form-floating">
         <select
           class="form-select"
@@ -40,7 +39,6 @@ function onRewayaChange(value) {
     </div>
 
     <div>
-      <span class="d-block mb-2">القارئ</span>
       <div class="form-floating">
         <select
           class="form-select"

--- a/src/shared/constants/storageKeys.js
+++ b/src/shared/constants/storageKeys.js
@@ -15,6 +15,11 @@ export const STORAGE_KEYS = {
   longitude: 'longitude',
   latitude: 'latitude',
   prayerTimesLayout: 'prayer-times-layout',
+  prayerCalcMethod: 'prayer-calc-method',
+  prayerCalcSchool: 'prayer-calc-school',
+  prayerCalcLatitudeAdjustment: 'prayer-calc-latitude-adjustment',
+  prayerCalcMidnightMode: 'prayer-calc-midnight-mode',
+  prayerCalcShafaq: 'prayer-calc-shafaq',
 
   currentReciter: 'currentReciter',
   currentTafseer: 'currentTafseer',


### PR DESCRIPTION
Add configurable calculation options (method, school, latitude adjustment,
midnight mode, shafaq) from the Aladhan /timings API to prayer time settings.
Each option defaults to "تلقائي" which omits the parameter from the request,
preserving the previous behavior of relying on the API's own defaults.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018X3rEHj6hxQ8khVnR4JQ91