### PR TITLE
Match sunnah prayers list icon size to prayer times icons

### DIFF
--- a/src/features/prayers/components/SunnahPrayers.vue
+++ b/src/features/prayers/components/SunnahPrayers.vue
@@ -114,4 +114,18 @@ const formatRakaa = (value) => {
   text-align: center;
   flex-shrink: 0;
 }
+
+/* Match the icon sizing of the prayer times list rows. */
+.icon-container {
+  display: grid;
+  place-items: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  flex-shrink: 0;
+
+  :deep(svg) {
+    width: 1.15rem;
+    height: 1.15rem;
+  }
+}
 </style>


### PR DESCRIPTION
The sunnah prayers list layout used the icon-container class without
defining it (it only exists in PrayerTimes.vue's scoped styles), so the
icons rendered at their intrinsic SVG size (~30px). Add the same scoped
sizing so both lists show 1.15rem icons in a 1.5rem container.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AZsQVRUXqMvdbDZG9Au1GC